### PR TITLE
feat: unify loading spinner across pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react-floating-action-button": "^1.0.5",
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
-        "react-loading-skeleton": "^3.5.0",
         "react-pdf": "^9.1.1",
         "react-qr-code": "^2.0.18",
         "react-router-dom": "^7.5.2",
@@ -6668,15 +6667,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
-    },
-    "node_modules/react-loading-skeleton": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.5.0.tgz",
-      "integrity": "sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
     },
     "node_modules/react-pdf": {
       "version": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-floating-action-button": "^1.0.5",
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
-    "react-loading-skeleton": "^3.5.0",
     "react-pdf": "^9.1.1",
     "react-qr-code": "^2.0.18",
     "react-router-dom": "^7.5.2",

--- a/src/Components/LoadingSpinner.jsx
+++ b/src/Components/LoadingSpinner.jsx
@@ -1,0 +1,5 @@
+export default function LoadingSpinner({ size = 'h-10 w-10', className = '' }) {
+  return (
+    <div className={`animate-spin rounded-full border-4 border-blue-500 border-t-transparent ${size} ${className}`}></div>
+  );
+}

--- a/src/Components/OrderStepsModal.jsx
+++ b/src/Components/OrderStepsModal.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import StepDetailsModal from "./StepDetailsModal";
 import { useNavigate } from "react-router-dom";
 import Vendor from "../Pages/vendor";
+import LoadingSpinner from "./LoadingSpinner";
 
 export default function OrderStepsModal({ order, onClose }) {
   const navigate = useNavigate();
@@ -145,7 +146,7 @@ if (savedSteps.length > 0) {
   if (loading) {
     return (
       <div className="modal-overlay fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
-        <div className="bg-white p-6 rounded-lg">Loading...</div>
+        <LoadingSpinner />
       </div>
     );
   }

--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -4,3 +4,4 @@ export { default as Card } from './Card';
 export { default as Modal } from './Modal';
 export { ToastContainer, toast } from './Toast';
 export { default as Table } from './Table';
+export { default as LoadingSpinner } from './LoadingSpinner';

--- a/src/Pages/AddTransaction.jsx
+++ b/src/Pages/AddTransaction.jsx
@@ -2,9 +2,9 @@ import { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
-import { FaSpinner } from 'react-icons/fa';
 import { Button, InputField, Card, ToastContainer, toast } from "../Components";
 import InvoiceModal from "../Components/InvoiceModal";
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 export default function AddTransaction({ editMode, existingData, onClose, onSuccess }) {
   const navigate = useNavigate();
@@ -213,7 +213,7 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
         <form onSubmit={submit}>
           {optionsLoading ? (
             <div className="flex justify-center items-center h-12 mb-4">
-              <FaSpinner className="animate-spin" />
+              <LoadingSpinner />
             </div>
           ) : (
             <div className="relative">
@@ -261,7 +261,7 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
 
           {optionsLoading ? (
             <div className="flex justify-center items-center h-10 mb-4">
-              <FaSpinner className="animate-spin" />
+              <LoadingSpinner />
             </div>
           ) : (
             <div className="mb-4">
@@ -318,7 +318,7 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
           >
             {loading ? (
               <>
-                <FaSpinner className="animate-spin mr-2" /> Saving...
+                <LoadingSpinner size="h-4 w-4" className="mr-2" /> Saving...
               </>
             ) : editMode ? (
               "Update"

--- a/src/Pages/CashLedger.jsx
+++ b/src/Pages/CashLedger.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import * as XLSX from 'xlsx';
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 const CashLedger = () => {
     const [transactions, setTransactions] = useState([]);
@@ -176,7 +177,7 @@ const CashLedger = () => {
                     </div>
 
                     {loading ? (
-                        <p className="text-gray-500 text-center py-10">Loading transactions...</p>
+                        <div className="flex justify-center py-10"><LoadingSpinner /></div>
                     ) : (
                         <>
                             <div className="mb-4 space-y-1 print:text-sm">

--- a/src/Pages/PendingTasks.jsx
+++ b/src/Pages/PendingTasks.jsx
@@ -1,6 +1,7 @@
 // src/components/PendingTasks.js
 
 import React from 'react';
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 export default function PendingTasks({ tasks = [], isLoading, onTaskClick }) {
   const pendingTasks = tasks.filter(task => task.Status === "Pending");
@@ -8,11 +9,7 @@ export default function PendingTasks({ tasks = [], isLoading, onTaskClick }) {
   return (
     <div className=" px-4 py-2">
       {isLoading ? (
-        <div className="space-y-4">
-          {[...Array(4)].map((_, i) => (
-            <div key={i} className=" h-28 rounded-xl animate-pulse" />
-          ))}
-        </div>
+        <div className="flex justify-center py-4"><LoadingSpinner /></div>
       ) : pendingTasks.length > 0 ? (
         <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 gap-2">
           {pendingTasks.map((task) => (

--- a/src/Pages/WhatsAppAdminPanel.jsx
+++ b/src/Pages/WhatsAppAdminPanel.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 const BASE_URL = 'https://misbackend-e078.onrender.com';
 
@@ -104,11 +105,11 @@ export default function WhatsAppAdminPanel() {
           onChange={(e) => setNewSessionId(e.target.value)}
         />
         <button
-          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 text-sm"
+          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 text-sm flex items-center justify-center"
           onClick={() => startSession(newSessionId)}
           disabled={loading}
         >
-          + Add
+          {loading ? <LoadingSpinner size="h-4 w-4" /> : '+ Add'}
         </button>
       </div>
 
@@ -143,10 +144,10 @@ export default function WhatsAppAdminPanel() {
               <td className="p-2 border space-x-2">
                 <button
                   onClick={() => startSession(s.sessionId)}
-                  className="bg-blue-500 text-white px-3 py-1 rounded text-xs hover:bg-blue-600"
+                  className="bg-blue-500 text-white px-3 py-1 rounded text-xs hover:bg-blue-600 flex items-center justify-center"
                   disabled={loading}
                 >
-                  Start
+                  {loading ? <LoadingSpinner size="h-4 w-4" /> : 'Start'}
                 </button>
                 <button
                   onClick={() => resetSession(s.sessionId)}

--- a/src/Pages/addOrder1.jsx
+++ b/src/Pages/addOrder1.jsx
@@ -3,9 +3,9 @@ import { useEffect, useState, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 import toast from "react-hot-toast";
-import { FaSpinner } from 'react-icons/fa';
 import AddCustomer from "./addCustomer";
 import InvoiceModal from "../Components/InvoiceModal";
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 export default function AddOrder1() {
   const navigate = useNavigate();
@@ -232,7 +232,7 @@ export default function AddOrder1() {
             {/* Customer Search */}
             {optionsLoading ? (
               <div className="flex justify-center items-center h-10 mb-4">
-                <FaSpinner className="animate-spin" />
+                <LoadingSpinner size="h-5 w-5" />
               </div>
             ) : (
               <div className="mb-4 relative">
@@ -305,11 +305,11 @@ export default function AddOrder1() {
                   />
                 </div>
 
-                {optionsLoading ? (
-                  <div className="flex justify-center items-center h-10 mb-4">
-                    <FaSpinner className="animate-spin" />
-                  </div>
-                ) : (
+                    {optionsLoading ? (
+                      <div className="flex justify-center items-center h-10 mb-4">
+                        <LoadingSpinner size="h-5 w-5" />
+                      </div>
+                    ) : (
                   <div className="mb-4">
                     <label className="block mb-1 font-medium">Payment Mode</label>
                     <select
@@ -332,7 +332,7 @@ export default function AddOrder1() {
             {/* Task Groups */}
             {optionsLoading ? (
               <div className="flex justify-center items-center h-10 mb-4">
-                <FaSpinner className="animate-spin" />
+                <LoadingSpinner size="h-5 w-5" />
               </div>
             ) : (
               <div className="mb-4">

--- a/src/Pages/addTransaction1.jsx
+++ b/src/Pages/addTransaction1.jsx
@@ -3,9 +3,9 @@ import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 import toast, { Toaster } from "react-hot-toast";
-import { FaSpinner } from 'react-icons/fa';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import InvoiceModal from "../Components/InvoiceModal";
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 export default function AddTransaction1() {
   const navigate = useNavigate();
@@ -186,7 +186,7 @@ export default function AddTransaction1() {
         <form onSubmit={submit}>
           {optionsLoading ? (
             <div className="d-flex justify-content-center align-items-center mb-3" style={{ height: '38px' }}>
-              <FaSpinner className="spinner-border" />
+              <LoadingSpinner size="h-5 w-5" />
             </div>
           ) : (
             <div className="mb-3 position-relative">
@@ -239,7 +239,7 @@ export default function AddTransaction1() {
 
           {optionsLoading ? (
             <div className="d-flex justify-content-center align-items-center mb-3" style={{ height: '38px' }}>
-              <FaSpinner className="spinner-border" />
+              <LoadingSpinner size="h-5 w-5" />
             </div>
           ) : (
             <div className="mb-3">
@@ -284,7 +284,7 @@ export default function AddTransaction1() {
             className="btn btn-success w-100"
             disabled={loading || !Amount || isNaN(Amount) || Amount <= 0 || !CreditCustomer || !DebitCustomer}
           >
-            {loading ? <><FaSpinner className="spinner-border spinner-border-sm me-2" /> Saving...</> : "Submit"}
+            {loading ? (<><LoadingSpinner size="h-4 w-4" className="me-2" /> Saving...</>) : "Submit"}
           </button>
         </form>
       </div>

--- a/src/Pages/adminHome.jsx
+++ b/src/Pages/adminHome.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
-import Skeleton from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
+import LoadingSpinner from "../Components/LoadingSpinner";
 import axios from 'axios';
 import OrderUpdate from '../Reports/orderUpdate'; 
 import AllOrder from "../Reports/allOrder";
@@ -252,9 +251,9 @@ const calculateWorkingHours = (inTime, outTime, breakTime, startTime) => {
       <AllOrder />
       <br /><br />
                  {isLoading ? (
-                       <Skeleton count={5} height={30} />
+                       <div className="flex justify-center py-4"><LoadingSpinner /></div>
                      ) : (
-                 <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">            
+                 <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">
                        { filteredOrders.map((order, index) => (
                          <div key={index}>
                      <div onClick={() => handleOrderClick(order)} className="grid grid-cols-5 gap-1 flex items-center p-1 bg-white rounded-lg shadow-inner cursor-pointer">
@@ -280,7 +279,7 @@ const calculateWorkingHours = (inTime, outTime, breakTime, startTime) => {
                 )} 
                
                {isLoading ? (
-  <Skeleton count={5} height={30} />
+  <div className="flex justify-center py-4"><LoadingSpinner /></div>
 ) : (
   <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">
   <table className="w-auto table-fixed border">

--- a/src/Pages/home.jsx
+++ b/src/Pages/home.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
-import "react-loading-skeleton/dist/skeleton.css";
 import axios from 'axios';
 import OrderUpdate from '../Reports/orderUpdate'; 
 import AllOrder from "../Reports/allOrder";

--- a/src/Pages/home1.jsx
+++ b/src/Pages/home1.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
-import Skeleton from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
+import LoadingSpinner from "../Components/LoadingSpinner";
 import axios from 'axios';
 import OrderUpdate from '../Reports/orderUpdate'; 
 import AddOrder1 from "./addOrder1";
@@ -123,9 +122,9 @@ const closeModal = () => {
     <>
       <br /><br />
             {isLoading ? (
-                  <Skeleton count={5} height={30} />
+                  <div className="flex justify-center py-4"><LoadingSpinner /></div>
                 ) : (
-            <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">            
+            <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">
                   { filteredOrders.map((order, index) => (
                     <div key={index}>
                 <div onClick={() => handleOrderClick(order)} className="grid grid-cols-5 gap-1 flex items-center p-1 bg-white rounded-lg shadow-inner cursor-pointer">

--- a/src/Pages/updateDelivery.jsx
+++ b/src/Pages/updateDelivery.jsx
@@ -8,6 +8,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { jsPDF } from 'jspdf';
 import html2canvas from 'html2canvas';
 import normalizeWhatsAppNumber from '../utils/normalizeNumber';
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 const BASE_URL = 'https://misbackend-e078.onrender.com';
 
@@ -301,10 +302,7 @@ export default function UpdateDelivery({ onClose, order = {}, mode = 'edit' }) {
   if (loading) {
     return (
       <div className="flex justify-center items-center min-h-screen bg-white">
-        <div className="text-center">
-          <div className="loader ease-linear rounded-full border-8 border-t-8 border-gray-200 h-20 w-20 mb-4 animate-spin"></div>
-          <h2 className="text-center text-gray-600">Loading...</h2>
-        </div>
+        <LoadingSpinner />
       </div>
     );
   }

--- a/src/Reports/allDelivery.jsx
+++ b/src/Reports/allDelivery.jsx
@@ -6,6 +6,7 @@ import "jspdf-autotable";
 import * as XLSX from "xlsx";
 
 import UpdateDelivery from "../Pages/updateDelivery";
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 export default function AllDelivery() {
   const navigate = useNavigate();
@@ -16,7 +17,6 @@ export default function AllDelivery() {
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedOrder, setSelectedOrder] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [visibleCount, setVisibleCount] = useState(20); // For lazy loading
 
   const formatDateDDMMYYYY = (dateString) => {
     const date = new Date(dateString);
@@ -63,7 +63,6 @@ export default function AllDelivery() {
       return matchesSearch && (filterValue === "" || task === filterValue);
     });
 
-  const visibleOrders = filteredOrders.slice(0, visibleCount);
 
   const exportPDF = () => {
     const doc = new jsPDF();
@@ -151,14 +150,14 @@ export default function AllDelivery() {
         {/* Loading Spinner */}
         {loading ? (
           <div className="flex justify-center items-center h-40">
-            <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600"></div>
+            <LoadingSpinner />
           </div>
         ) : (
           <>
             {/* Orders Grid */}
             <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-9 gap-2">
-              {visibleOrders.length > 0 ? (
-                visibleOrders.map((order, index) => (
+              {filteredOrders.length > 0 ? (
+                filteredOrders.map((order, index) => (
                   <div
                     key={index}
                     onClick={() => handleEditClick(order)}
@@ -180,22 +179,10 @@ export default function AllDelivery() {
                   No orders found
                 </div>
               )}
-            </div>
-
-            {/* Load More */}
-            {visibleCount < filteredOrders.length && (
-              <div className="flex justify-center mt-6">
-                <button
-                  onClick={() => setVisibleCount((prev) => prev + 20)}
-                  className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-full shadow"
-                >
-                  Load More
-                </button>
               </div>
-            )}
-          </>
-        )}
-      </div>
+            </>
+          )}
+        </div>
 
       {/* Edit Modal */}
       {showEditModal && (

--- a/src/Reports/allOrder.jsx
+++ b/src/Reports/allOrder.jsx
@@ -1,11 +1,9 @@
-import React, { useState, useEffect, Suspense, lazy } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
-import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
 import { useNavigate } from "react-router-dom";
-
-const AddOrder1 = lazy(() => import("../Pages/addOrder1"));
-const OrderUpdate = lazy(() => import("./orderUpdate"));
+import LoadingSpinner from "../Components/LoadingSpinner";
+import AddOrder1 from "../Pages/addOrder1";
+import OrderUpdate from "./orderUpdate";
 
 export default function AllOrder() {
     const navigate = useNavigate();
@@ -124,22 +122,19 @@ export default function AllOrder() {
 
                     <main className="flex flex-1 p-2 overflow-y-auto">
                         <div className="w-full mx-auto">
-                            <SkeletonTheme>
-                                {isLoading
-                                    ? Array(5).fill().map((_, index) => (
-                                        <Skeleton key={index} height={80} width="100%" style={{ marginBottom: "5px" }} />
-                                    ))
-                                    : taskOptions.length === 0 ? (
-                                        <div className="text-center text-gray-400 py-10">No tasks found.</div>
-                                    ) : (
-                                        taskOptions.map((taskGroup) => {
-                                            const taskGroupOrders = filteredOrders.filter(order => order.highestStatusTask?.Task === taskGroup);
+                            {isLoading ? (
+                                <div className="flex justify-center py-4"><LoadingSpinner /></div>
+                            ) : taskOptions.length === 0 ? (
+                                <div className="text-center text-gray-400 py-10">No tasks found.</div>
+                            ) : (
+                                taskOptions.map((taskGroup) => {
+                                    const taskGroupOrders = filteredOrders.filter(order => order.highestStatusTask?.Task === taskGroup);
 
-                                            if (taskGroupOrders.length === 0) return null;
+                                    if (taskGroupOrders.length === 0) return null;
 
-                                            return (
-                                                <div key={taskGroup} className="mb-2 p-2  rounded-lg">
-                                                    <h3 className="font-semibold text-lg text-green-700 mb-3">{taskGroup}</h3>
+                                    return (
+                                        <div key={taskGroup} className="mb-2 p-2  rounded-lg">
+                                            <h3 className="font-semibold text-lg text-green-700 mb-3">{taskGroup}</h3>
                                                     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-10 gap-2">
                                                         {taskGroupOrders.map((order) => {
                                                             let latestStatusDate = order.highestStatusTask?.CreatedAt
@@ -200,28 +195,21 @@ export default function AllOrder() {
                                             );
                                         })
                                     )}
-                            </SkeletonTheme>
                         </div>
                     </main>
 
                 </div>
 
-                <Suspense fallback={
-                    <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-30 z-50">
-                        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-500"></div>
-                    </div>
-                }>
-                    {showOrderModal && (
-                        <Modal onClose={closeModal}>
-                            <AddOrder1 closeModal={closeModal} />
-                        </Modal>
-                    )}
-                    {showEditModal && (
-                        <Modal onClose={closeEditModal}>
-                            <OrderUpdate order={selectedOrder} onClose={closeEditModal} />
-                        </Modal>
-                    )}
-                </Suspense>
+                {showOrderModal && (
+                    <Modal onClose={closeModal}>
+                        <AddOrder1 closeModal={closeModal} />
+                    </Modal>
+                )}
+                {showEditModal && (
+                    <Modal onClose={closeEditModal}>
+                        <OrderUpdate order={selectedOrder} onClose={closeEditModal} />
+                    </Modal>
+                )}
             </div>
         </>
     );

--- a/src/Reports/allOrderMobile.jsx
+++ b/src/Reports/allOrderMobile.jsx
@@ -1,11 +1,9 @@
-import React, { useState, useEffect, Suspense, lazy } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
-import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
 import { useNavigate } from "react-router-dom";
-
-const AddOrder1 = lazy(() => import("../Pages/addOrder1"));
-const OrderUpdate = lazy(() => import("./orderUpdate"));
+import LoadingSpinner from "../Components/LoadingSpinner";
+import AddOrder1 from "../Pages/addOrder1";
+import OrderUpdate from "./orderUpdate";
 
 export default function AllOrder() {
     const navigate = useNavigate();
@@ -126,40 +124,36 @@ export default function AllOrder() {
 
                     <div className="overflow-x-scroll flex space-x-1 py-0" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
                         <style>{`.overflow-x-scroll::-webkit-scrollbar {display: none;}`}</style>
-                        <SkeletonTheme highlightColor="#b4cf97">
-                            {isLoading
-                                ? Array(3).fill().map((_, index) => (
-                                    <Skeleton key={index} height={40} width={100} style={{ margin: "0 5px" }} />
-                                ))
-                                : taskOptions.map((taskGroup) => (
-                                    <button
-                                        key={taskGroup}
-                                        onClick={() => {
-                                            setFilter(taskGroup);
-                                        }}
-                                        className={`sanju ${filter === taskGroup ? "bg-green-200" : "bg-gray-100"} uppercase rounded-full text-black p-2 text-xs me-1`}
-                                    >
-                                        {taskGroup}
-                                    </button>
-                                ))}
-                        </SkeletonTheme>
+                        {isLoading ? (
+                            <div className="flex justify-center py-4 w-full"><LoadingSpinner /></div>
+                        ) : (
+                            taskOptions.map((taskGroup) => (
+                                <button
+                                    key={taskGroup}
+                                    onClick={() => {
+                                        setFilter(taskGroup);
+                                    }}
+                                    className={`sanju ${filter === taskGroup ? "bg-green-200" : "bg-gray-100"} uppercase rounded-full text-black p-2 text-xs me-1`}
+                                >
+                                    {taskGroup}
+                                </button>
+                            ))
+                        )}
                     </div>
 
                     <main className="flex flex-1 p-2 overflow-y-auto">
                         <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">
-                            <SkeletonTheme highlightColor="#b4cf97">
-                                {isLoading
-                                    ? Array(5).fill().map((_, index) => (
-                                        <Skeleton key={index} height={80} width="100%" style={{ marginBottom: "10px" }} />
-                                    ))
-                                    : filteredOrders.map((order) => (
-                                        <div key={order.Order_uuid || order.Order_Number}>
-                                            <div
-                                                onClick={() => handleEditClick(order)}
-                                                className="grid grid-cols-5 gap-1 flex items-center p-1 bg-white rounded-lg shadow-inner cursor-pointer"
-                                                role="button"
-                                                tabIndex={0}
-                                            >
+                            {isLoading ? (
+                                <div className="flex justify-center py-4"><LoadingSpinner /></div>
+                            ) : (
+                                filteredOrders.map((order) => (
+                                    <div key={order.Order_uuid || order.Order_Number}>
+                                        <div
+                                            onClick={() => handleEditClick(order)}
+                                            className="grid grid-cols-5 gap-1 flex items-center p-1 bg-white rounded-lg shadow-inner cursor-pointer"
+                                            role="button"
+                                            tabIndex={0}
+                                        >
                                                 <div className="w-12 h-12 p-2 col-start-1 col-end-1 bg-gray-100 rounded-full flex items-center justify-center">
                                                     <strong className="text-l text-gray-500">{order.Order_Number}</strong>
                                                 </div>
@@ -180,26 +174,23 @@ export default function AllOrder() {
                                             </div>
                                         </div>
                                     ))}
-                            </SkeletonTheme>
                         </div>
                     </main>
                 </div>
 
-                <Suspense fallback={<div className="text-center py-4">Loading...</div>}>
-                    {showOrderModal && (
-                        <div className="modal-overlay">
-                            <div className="modal-content">
-                                <AddOrder1 closeModal={closeModal} />
-                            </div>
+                {showOrderModal && (
+                    <div className="modal-overlay">
+                        <div className="modal-content">
+                            <AddOrder1 closeModal={closeModal} />
                         </div>
-                    )}
+                    </div>
+                )}
 
-                    {showEditModal && (
-                        <div className="modal-overlay fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center">
-                            <OrderUpdate order={selectedOrder} onClose={closeEditModal} />
-                        </div>
-                    )}
-                </Suspense>
+                {showEditModal && (
+                    <div className="modal-overlay fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center">
+                        <OrderUpdate order={selectedOrder} onClose={closeEditModal} />
+                    </div>
+                )}
 
             </div>
         </>

--- a/src/Reports/allTransaction3.jsx
+++ b/src/Reports/allTransaction3.jsx
@@ -5,6 +5,7 @@ import AddOrder1 from "../Pages/addOrder1";
 import jsPDF from 'jspdf';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
+import LoadingSpinner from "../Components/LoadingSpinner";
 
 const AllTransaction3 = () => {
     const [transactions, setTransactions] = useState([]);
@@ -220,7 +221,7 @@ const AllTransaction3 = () => {
                     Closing Balance: ₹{totals.total.toFixed(2)}
                 </p>
                 {loading ? (
-                    <div className="text-center py-12 text-lg">Loading transactions...</div>
+                    <div className="flex justify-center py-12"><LoadingSpinner /></div>
                 ) : (
                     <div className="overflow-x-auto">
                         <table className="min-w-full border-collapse">


### PR DESCRIPTION
## Summary
- add shared `LoadingSpinner` component and export through components index
- replace skeletons and disparate loaders with the new spinner across pages
- drop React.lazy usage and remove lazy loading blocks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 383 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68945f4b48288322b483a16b1bf66d47