### PR TITLE
refactor: unify loading spinner and improve mobile UI

### DIFF
--- a/src/Components/LoadingSpinner.jsx
+++ b/src/Components/LoadingSpinner.jsx
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+
+export default function LoadingSpinner({ size = 24, className = '' }) {
+  return (
+    <div
+      className={`animate-spin rounded-full border-4 border-current border-t-transparent text-blue-500 ${className}`}
+      style={{ width: size, height: size }}
+    />
+  );
+}
+
+LoadingSpinner.propTypes = {
+  size: PropTypes.number,
+  className: PropTypes.string,
+};

--- a/src/Components/LoadingSpinner.jsx
+++ b/src/Components/LoadingSpinner.jsx
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
 
-export default function LoadingSpinner({ size = 24, className = '' }) {
+export default function LoadingSpinner({ size = 24, className = 'text-primary' }) {
   return (
     <div
-      className={`animate-spin rounded-full border-4 border-current border-t-transparent text-blue-500 ${className}`}
+      className={`animate-spin rounded-full border-4 border-current border-t-transparent ${className}`}
       style={{ width: size, height: size }}
+      role="status"
+      aria-label="Loading"
     />
   );
 }

--- a/src/Components/Modal.jsx
+++ b/src/Components/Modal.jsx
@@ -11,7 +11,7 @@ export default function Modal({
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 w-full max-w-md relative">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 w-full max-w-md mx-4 relative max-h-[90vh] overflow-y-auto">
         {title && <h2 className="text-lg font-semibold mb-4">{title}</h2>}
         <div>{children}</div>
         {actions && <div className="mt-4 flex justify-end space-x-2">{actions}</div>}

--- a/src/Components/TopNavbar.jsx
+++ b/src/Components/TopNavbar.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import axios from "axios";
+import { LoadingSpinner } from "../Components";
 
 const TopNavbar = () => {
   const [userGroup, setUserGroup] = useState("");
@@ -160,7 +160,7 @@ const TopNavbar = () => {
 
       {isLoading && (
         <div className="fixed top-0 left-0 w-full h-full bg-white opacity-70 z-40 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-t-4 border-primary border-solid"></div>
+          <LoadingSpinner size={48} className="text-primary" />
         </div>
       )}
     </>

--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -4,3 +4,4 @@ export { default as Card } from './Card';
 export { default as Modal } from './Modal';
 export { ToastContainer, toast } from './Toast';
 export { default as Table } from './Table';
+export { default as LoadingSpinner } from './LoadingSpinner';

--- a/src/Pages/AddTransaction.jsx
+++ b/src/Pages/AddTransaction.jsx
@@ -2,8 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
-import { FaSpinner } from 'react-icons/fa';
-import { Button, InputField, Card, ToastContainer, toast } from "../Components";
+import { Button, InputField, Card, ToastContainer, toast, LoadingSpinner } from "../Components";
 import InvoiceModal from "../Components/InvoiceModal";
 
 export default function AddTransaction({ editMode, existingData, onClose, onSuccess }) {
@@ -213,7 +212,7 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
         <form onSubmit={submit}>
           {optionsLoading ? (
             <div className="flex justify-center items-center h-12 mb-4">
-              <FaSpinner className="animate-spin" />
+              <LoadingSpinner />
             </div>
           ) : (
             <div className="relative">
@@ -261,7 +260,7 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
 
           {optionsLoading ? (
             <div className="flex justify-center items-center h-10 mb-4">
-              <FaSpinner className="animate-spin" />
+              <LoadingSpinner />
             </div>
           ) : (
             <div className="mb-4">
@@ -318,7 +317,7 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
           >
             {loading ? (
               <>
-                <FaSpinner className="animate-spin mr-2" /> Saving...
+                <LoadingSpinner size={16} className="mr-2" /> Saving...
               </>
             ) : editMode ? (
               "Update"

--- a/src/Pages/addOrder1.jsx
+++ b/src/Pages/addOrder1.jsx
@@ -3,9 +3,9 @@ import { useEffect, useState, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 import toast from "react-hot-toast";
-import { FaSpinner } from 'react-icons/fa';
 import AddCustomer from "./addCustomer";
 import InvoiceModal from "../Components/InvoiceModal";
+import { LoadingSpinner } from "../Components";
 
 export default function AddOrder1() {
   const navigate = useNavigate();
@@ -232,7 +232,7 @@ export default function AddOrder1() {
             {/* Customer Search */}
             {optionsLoading ? (
               <div className="flex justify-center items-center h-10 mb-4">
-                <FaSpinner className="animate-spin" />
+                <LoadingSpinner />
               </div>
             ) : (
               <div className="mb-4 relative">
@@ -307,7 +307,7 @@ export default function AddOrder1() {
 
                 {optionsLoading ? (
                   <div className="flex justify-center items-center h-10 mb-4">
-                    <FaSpinner className="animate-spin" />
+                    <LoadingSpinner />
                   </div>
                 ) : (
                   <div className="mb-4">
@@ -332,7 +332,7 @@ export default function AddOrder1() {
             {/* Task Groups */}
             {optionsLoading ? (
               <div className="flex justify-center items-center h-10 mb-4">
-                <FaSpinner className="animate-spin" />
+                <LoadingSpinner />
               </div>
             ) : (
               <div className="mb-4">

--- a/src/Pages/addTransaction1.jsx
+++ b/src/Pages/addTransaction1.jsx
@@ -3,9 +3,9 @@ import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 import toast, { Toaster } from "react-hot-toast";
-import { FaSpinner } from 'react-icons/fa';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import InvoiceModal from "../Components/InvoiceModal";
+import { LoadingSpinner } from "../Components";
 
 export default function AddTransaction1() {
   const navigate = useNavigate();
@@ -186,7 +186,7 @@ export default function AddTransaction1() {
         <form onSubmit={submit}>
           {optionsLoading ? (
             <div className="d-flex justify-content-center align-items-center mb-3" style={{ height: '38px' }}>
-              <FaSpinner className="spinner-border" />
+              <LoadingSpinner />
             </div>
           ) : (
             <div className="mb-3 position-relative">
@@ -239,7 +239,7 @@ export default function AddTransaction1() {
 
           {optionsLoading ? (
             <div className="d-flex justify-content-center align-items-center mb-3" style={{ height: '38px' }}>
-              <FaSpinner className="spinner-border" />
+              <LoadingSpinner />
             </div>
           ) : (
             <div className="mb-3">
@@ -284,7 +284,7 @@ export default function AddTransaction1() {
             className="btn btn-success w-100"
             disabled={loading || !Amount || isNaN(Amount) || Amount <= 0 || !CreditCustomer || !DebitCustomer}
           >
-            {loading ? <><FaSpinner className="spinner-border spinner-border-sm me-2" /> Saving...</> : "Submit"}
+            {loading ? <><LoadingSpinner size={16} className="me-2" /> Saving...</> : "Submit"}
           </button>
         </form>
       </div>

--- a/src/Pages/adminHome.jsx
+++ b/src/Pages/adminHome.jsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
-import Skeleton from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
 import axios from 'axios';
-import OrderUpdate from '../Reports/orderUpdate'; 
+import OrderUpdate from '../Reports/orderUpdate';
 import AllOrder from "../Reports/allOrder";
 import UserTask from "./userTask";
 import { format } from 'date-fns';
 import TaskUpdate from "./taskUpdate";
+import { LoadingSpinner } from "../Components";
 
 export default function AdminHome() {
   const navigate = useNavigate();
@@ -252,9 +251,9 @@ const calculateWorkingHours = (inTime, outTime, breakTime, startTime) => {
       <AllOrder />
       <br /><br />
                  {isLoading ? (
-                       <Skeleton count={5} height={30} />
+                       <div className="flex justify-center py-4"><LoadingSpinner /></div>
                      ) : (
-                 <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">            
+                 <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">
                        { filteredOrders.map((order, index) => (
                          <div key={index}>
                      <div onClick={() => handleOrderClick(order)} className="grid grid-cols-5 gap-1 flex items-center p-1 bg-white rounded-lg shadow-inner cursor-pointer">
@@ -280,7 +279,7 @@ const calculateWorkingHours = (inTime, outTime, breakTime, startTime) => {
                 )} 
                
                {isLoading ? (
-  <Skeleton count={5} height={30} />
+  <div className="flex justify-center py-4"><LoadingSpinner /></div>
 ) : (
   <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">
   <table className="w-auto table-fixed border">

--- a/src/Pages/home.jsx
+++ b/src/Pages/home.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
-import "react-loading-skeleton/dist/skeleton.css";
 import axios from 'axios';
 import OrderUpdate from '../Reports/orderUpdate'; 
 import AllOrder from "../Reports/allOrder";

--- a/src/Pages/home1.jsx
+++ b/src/Pages/home1.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
-import Skeleton from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
 import axios from 'axios';
-import OrderUpdate from '../Reports/orderUpdate'; 
+import OrderUpdate from '../Reports/orderUpdate';
 import AddOrder1 from "./addOrder1";
+import { LoadingSpinner } from "../Components";
 
 export default function Home() {
   const navigate = useNavigate();
@@ -123,9 +122,9 @@ const closeModal = () => {
     <>
       <br /><br />
             {isLoading ? (
-                  <Skeleton count={5} height={30} />
+                  <div className="flex justify-center py-4"><LoadingSpinner /></div>
                 ) : (
-            <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">            
+            <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">
                   { filteredOrders.map((order, index) => (
                     <div key={index}>
                 <div onClick={() => handleOrderClick(order)} className="grid grid-cols-5 gap-1 flex items-center p-1 bg-white rounded-lg shadow-inner cursor-pointer">

--- a/src/Pages/updateDelivery.jsx
+++ b/src/Pages/updateDelivery.jsx
@@ -8,6 +8,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { jsPDF } from 'jspdf';
 import html2canvas from 'html2canvas';
 import normalizeWhatsAppNumber from '../utils/normalizeNumber';
+import { LoadingSpinner } from "../Components";
 
 const BASE_URL = 'https://misbackend-e078.onrender.com';
 
@@ -303,7 +304,7 @@ export default function UpdateDelivery({ onClose, order = {}, mode = 'edit' }) {
     return (
       <div className="flex justify-center items-center min-h-screen bg-white">
         <div className="text-center">
-          <div className="loader ease-linear rounded-full border-8 border-t-8 border-gray-200 h-20 w-20 mb-4 animate-spin"></div>
+          <LoadingSpinner size={80} className="mb-4" />
           <h2 className="text-center text-gray-600">Loading...</h2>
         </div>
       </div>

--- a/src/Reports/allDelivery.jsx
+++ b/src/Reports/allDelivery.jsx
@@ -6,6 +6,7 @@ import "jspdf-autotable";
 import * as XLSX from "xlsx";
 
 import UpdateDelivery from "../Pages/updateDelivery";
+import { LoadingSpinner } from "../Components";
 
 export default function AllDelivery() {
   const navigate = useNavigate();
@@ -16,7 +17,6 @@ export default function AllDelivery() {
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedOrder, setSelectedOrder] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [visibleCount, setVisibleCount] = useState(20); // For lazy loading
 
   const formatDateDDMMYYYY = (dateString) => {
     const date = new Date(dateString);
@@ -78,9 +78,6 @@ export default function AllDelivery() {
       hasItems
     );
   });
-
-const visibleOrders = filteredOrders;
-
 
   const exportPDF = () => {
     const doc = new jsPDF();
@@ -168,14 +165,14 @@ const visibleOrders = filteredOrders;
         {/* Loading Spinner */}
         {loading ? (
           <div className="flex justify-center items-center h-40">
-            <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600"></div>
+            <LoadingSpinner size={40} />
           </div>
         ) : (
           <>
             {/* Orders Grid */}
             <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-9 gap-2">
-              {visibleOrders.length > 0 ? (
-                visibleOrders.map((order, index) => (
+              {filteredOrders.length > 0 ? (
+                filteredOrders.map((order, index) => (
                   <div
                     key={index}
                     onClick={() => handleEditClick(order)}

--- a/src/Reports/allOrder.jsx
+++ b/src/Reports/allOrder.jsx
@@ -1,11 +1,9 @@
-import React, { useState, useEffect, Suspense, lazy } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
-import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
 import { useNavigate } from "react-router-dom";
-
-const AddOrder1 = lazy(() => import("../Pages/addOrder1"));
-const OrderUpdate = lazy(() => import("./orderUpdate"));
+import AddOrder1 from "../Pages/addOrder1";
+import OrderUpdate from "./orderUpdate";
+import { LoadingSpinner } from "../Components";
 
 export default function AllOrder() {
     const navigate = useNavigate();
@@ -124,104 +122,94 @@ export default function AllOrder() {
 
                     <main className="flex flex-1 p-2 overflow-y-auto">
                         <div className="w-full mx-auto">
-                            <SkeletonTheme>
-                                {isLoading
-                                    ? Array(5).fill().map((_, index) => (
-                                        <Skeleton key={index} height={80} width="100%" style={{ marginBottom: "5px" }} />
-                                    ))
-                                    : taskOptions.length === 0 ? (
-                                        <div className="text-center text-gray-400 py-10">No tasks found.</div>
-                                    ) : (
-                                        taskOptions.map((taskGroup) => {
-                                            const taskGroupOrders = filteredOrders.filter(order => order.highestStatusTask?.Task === taskGroup);
+                            {isLoading ? (
+                                <div className="flex justify-center py-4"><LoadingSpinner /></div>
+                            ) : taskOptions.length === 0 ? (
+                                <div className="text-center text-gray-400 py-10">No tasks found.</div>
+                            ) : (
+                                taskOptions.map((taskGroup) => {
+                                    const taskGroupOrders = filteredOrders.filter(order => order.highestStatusTask?.Task === taskGroup);
 
-                                            if (taskGroupOrders.length === 0) return null;
+                                    if (taskGroupOrders.length === 0) return null;
 
-                                            return (
-                                                <div key={taskGroup} className="mb-2 p-2  rounded-lg">
-                                                    <h3 className="font-semibold text-lg text-green-700 mb-3">{taskGroup}</h3>
-                                                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-10 gap-2">
-                                                        {taskGroupOrders.map((order) => {
-                                                            let latestStatusDate = order.highestStatusTask?.CreatedAt
-                                                                ? new Date(order.highestStatusTask.CreatedAt)
-                                                                : null;
-                                                            let timeDifference = 0;
-                                                            let formattedDate = '';
-                                                            if (latestStatusDate) {
-                                                                const today = new Date();
-                                                                today.setHours(0, 0, 0, 0);
-                                                                const latest = new Date(latestStatusDate);
-                                                                latest.setHours(0, 0, 0, 0);
-                                                                const diffTime = today - latest;
-                                                                timeDifference = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-                                                                formattedDate = latestStatusDate.toLocaleDateString();
-                                                            }
-                                                            let cardClass = "bg-white";
-                                                            if (timeDifference === 0) cardClass = "bg-green-100";
-                                                            else if (timeDifference === 1) cardClass = "bg-yellow-100";
-                                                            else if (timeDifference >= 2) cardClass = "bg-red-100";
+                                    return (
+                                        <div key={taskGroup} className="mb-2 p-2  rounded-lg">
+                                            <h3 className="font-semibold text-lg text-green-700 mb-3">{taskGroup}</h3>
+                                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-10 gap-2">
+                                                {taskGroupOrders.map((order) => {
+                                                    let latestStatusDate = order.highestStatusTask?.CreatedAt
+                                                        ? new Date(order.highestStatusTask.CreatedAt)
+                                                        : null;
+                                                    let timeDifference = 0;
+                                                    let formattedDate = '';
+                                                    if (latestStatusDate) {
+                                                        const today = new Date();
+                    today.setHours(0, 0, 0, 0);
+                                                        const latest = new Date(latestStatusDate);
+                                                        latest.setHours(0, 0, 0, 0);
+                                                        const diffTime = today - latest;
+                                                        timeDifference = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+                                                        formattedDate = latestStatusDate.toLocaleDateString();
+                                                    }
+                                                    let cardClass = "bg-white";
+                                                    if (timeDifference === 0) cardClass = "bg-green-100";
+                                                    else if (timeDifference === 1) cardClass = "bg-yellow-100";
+                                                    else if (timeDifference >= 2) cardClass = "bg-red-100";
 
-                                                            return (
-                                                                <div
-                                                                    key={order.Order_uuid}
-                                                                    className={`${cardClass} rounded-lg p-2 cursor-pointer hover:bg-green-50 transition-all`}
-                                                                    onClick={() => handleEditClick(order)}
-                                                                >
-                                                                    {/* Row 1: Customer Name */}
-                                                                    <div className="font-medium text-gray-800 truncate mb-1 text-sm">
-                                                                        {order.Customer_name}
-                                                                    </div>
+                                                    return (
+                                                        <div
+                                                            key={order.Order_uuid}
+                                                            className={`${cardClass} rounded-lg p-2 cursor-pointer hover:bg-green-50 transition-all`}
+                                                            onClick={() => handleEditClick(order)}
+                                                        >
+                                                            {/* Row 1: Customer Name */}
+                                                            <div className="font-medium text-gray-800 truncate mb-1 text-sm">
+                                                                {order.Customer_name}
+                                                            </div>
 
-                                                                    {/* Row 2: Order Number and Delay */}
-                                                                    <div className="flex justify-between items-center mb-1">
-                                                                        <span className="text-sm font-semibold text-green-700">{order.Order_Number}</span>
-                                                                        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full
-                                                                            ${timeDifference === 0
-                                                                                ? 'bg-green-200 text-green-800'
-                                                                                : timeDifference === 1
-                                                                                    ? 'bg-yellow-200 text-yellow-800'
-                                                                                    : 'bg-red-200 text-red-800'}
-                                                                        `}>
-                                                                            {timeDifference === 0
-                                                                                ? 'Today'
-                                                                                : timeDifference === 1
-                                                                                    ? '1 day'
-                                                                                    : `${timeDifference} days`}
-                                                                        </span>
-                                                                    </div>
+                                                            {/* Row 2: Order Number and Delay */}
+                                                            <div className="flex justify-between items-center mb-1">
+                                                                <span className="text-sm font-semibold text-green-700">{order.Order_Number}</span>
+                                                                <span className={`text-xs font-semibold px-2 py-0.5 rounded-full
+                                                                    ${timeDifference === 0
+                                                                        ? 'bg-green-200 text-green-800'
+                                                                        : timeDifference === 1
+                                                                            ? 'bg-yellow-200 text-yellow-800'
+                                                                            : 'bg-red-200 text-red-800'}
+                                                                `}>
+                                                                    {timeDifference === 0
+                                                                        ? 'Today'
+                                                                        : timeDifference === 1
+                                                                            ? '1 day'
+                                                                            : `${timeDifference} days`}
+                                                                </span>
+                                                            </div>
 
-                                                                    {/* Row 3: Latest Status Date */}
-                                                                    <div className="text-xs text-gray-500 text-right">{formattedDate}</div>
-                                                                </div>
-                                                            );
-                                                        })}
-                                                    </div>
-                                                </div>
-                                            );
-                                        })
-                                    )}
-                            </SkeletonTheme>
+                                                            {/* Row 3: Latest Status Date */}
+                                                            <div className="text-xs text-gray-500 text-right">{formattedDate}</div>
+                                                        </div>
+                                                    );
+                                                })}
+                                            </div>
+                                        </div>
+                                    );
+                                })
+                            )}
                         </div>
                     </main>
 
                 </div>
 
-                <Suspense fallback={
-                    <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-30 z-50">
-                        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-500"></div>
-                    </div>
-                }>
-                    {showOrderModal && (
-                        <Modal onClose={closeModal}>
-                            <AddOrder1 closeModal={closeModal} />
-                        </Modal>
-                    )}
-                    {showEditModal && (
-                        <Modal onClose={closeEditModal}>
-                            <OrderUpdate order={selectedOrder} onClose={closeEditModal} />
-                        </Modal>
-                    )}
-                </Suspense>
+                {showOrderModal && (
+                    <Modal onClose={closeModal}>
+                        <AddOrder1 closeModal={closeModal} />
+                    </Modal>
+                )}
+                {showEditModal && (
+                    <Modal onClose={closeEditModal}>
+                        <OrderUpdate order={selectedOrder} onClose={closeEditModal} />
+                    </Modal>
+                )}
             </div>
         </>
     );
@@ -237,7 +225,7 @@ function Modal({ onClose, children }) {
                 if (e.target === e.currentTarget) onClose();
             }}
         >
-            <div className="bg-white rounded-xl p-6 w-full max-w-2xl mx-4 relative">
+            <div className="bg-white rounded-xl p-6 w-full max-w-2xl mx-4 relative max-h-[90vh] overflow-y-auto">
                 <button
                     className="absolute right-2 top-2 text-xl text-gray-400 hover:text-green-500"
                     onClick={onClose}

--- a/src/Reports/allOrderMobile.jsx
+++ b/src/Reports/allOrderMobile.jsx
@@ -1,11 +1,9 @@
-import React, { useState, useEffect, Suspense, lazy } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
-import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
 import { useNavigate } from "react-router-dom";
-
-const AddOrder1 = lazy(() => import("../Pages/addOrder1"));
-const OrderUpdate = lazy(() => import("./orderUpdate"));
+import AddOrder1 from "../Pages/addOrder1";
+import OrderUpdate from "./orderUpdate";
+import { LoadingSpinner } from "../Components";
 
 export default function AllOrder() {
     const navigate = useNavigate();
@@ -126,80 +124,74 @@ export default function AllOrder() {
 
                     <div className="overflow-x-scroll flex space-x-1 py-0" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
                         <style>{`.overflow-x-scroll::-webkit-scrollbar {display: none;}`}</style>
-                        <SkeletonTheme highlightColor="#b4cf97">
-                            {isLoading
-                                ? Array(3).fill().map((_, index) => (
-                                    <Skeleton key={index} height={40} width={100} style={{ margin: "0 5px" }} />
-                                ))
-                                : taskOptions.map((taskGroup) => (
-                                    <button
-                                        key={taskGroup}
-                                        onClick={() => {
-                                            setFilter(taskGroup);
-                                        }}
-                                        className={`sanju ${filter === taskGroup ? "bg-green-200" : "bg-gray-100"} uppercase rounded-full text-black p-2 text-xs me-1`}
-                                    >
-                                        {taskGroup}
-                                    </button>
-                                ))}
-                        </SkeletonTheme>
+                        {isLoading ? (
+                            <div className="flex justify-center py-4 w-full"><LoadingSpinner /></div>
+                        ) : (
+                            taskOptions.map((taskGroup) => (
+                                <button
+                                    key={taskGroup}
+                                    onClick={() => {
+                                        setFilter(taskGroup);
+                                    }}
+                                    className={`sanju ${filter === taskGroup ? "bg-green-200" : "bg-gray-100"} uppercase rounded-full text-black p-2 text-xs me-1`}
+                                >
+                                    {taskGroup}
+                                </button>
+                            ))
+                        )}
                     </div>
 
                     <main className="flex flex-1 p-2 overflow-y-auto">
                         <div className="flex flex-col w-100 space-y-2 max-w-md mx-auto">
-                            <SkeletonTheme highlightColor="#b4cf97">
-                                {isLoading
-                                    ? Array(5).fill().map((_, index) => (
-                                        <Skeleton key={index} height={80} width="100%" style={{ marginBottom: "10px" }} />
-                                    ))
-                                    : filteredOrders.map((order) => (
-                                        <div key={order.Order_uuid || order.Order_Number}>
-                                            <div
-                                                onClick={() => handleEditClick(order)}
-                                                className="grid grid-cols-5 gap-1 flex items-center p-1 bg-white rounded-lg shadow-inner cursor-pointer"
-                                                role="button"
-                                                tabIndex={0}
-                                            >
-                                                <div className="w-12 h-12 p-2 col-start-1 col-end-1 bg-gray-100 rounded-full flex items-center justify-center">
-                                                    <strong className="text-l text-gray-500">{order.Order_Number}</strong>
-                                                </div>
-                                                <div className="p-2 col-start-2 col-end-8">
-                                                    <strong className="text-l text-gray-900">{order.Customer_name}</strong><br />
-                                                    <label className="text-xs">
-                                                        {order.highestStatusTask?.CreatedAt ? new Date(order.highestStatusTask.CreatedAt).toLocaleDateString() : ''} - {order.Remark}
-                                                    </label>
-                                                </div>
-                                                <div className="items-center justify-center text-right col-end-9 col-span-1">
-                                                    <label className="text-xs pr-2">
-                                                        {order.highestStatusTask?.Delivery_Date ? new Date(order.highestStatusTask.Delivery_Date).toLocaleDateString() : ''}
-                                                    </label><br />
-                                                    <label className="text-s text-green-500 pr-2">
-                                                        {order.highestStatusTask?.Assigned}
-                                                    </label>
-                                                </div>
+                            {isLoading ? (
+                                <div className="flex justify-center py-4"><LoadingSpinner /></div>
+                            ) : (
+                                filteredOrders.map((order) => (
+                                    <div key={order.Order_uuid || order.Order_Number}>
+                                        <div
+                                            onClick={() => handleEditClick(order)}
+                                            className="grid grid-cols-5 gap-1 flex items-center p-1 bg-white rounded-lg shadow-inner cursor-pointer"
+                                            role="button"
+                                            tabIndex={0}
+                                        >
+                                            <div className="w-12 h-12 p-2 col-start-1 col-end-1 bg-gray-100 rounded-full flex items-center justify-center">
+                                                <strong className="text-l text-gray-500">{order.Order_Number}</strong>
+                                            </div>
+                                            <div className="p-2 col-start-2 col-end-8">
+                                                <strong className="text-l text-gray-900">{order.Customer_name}</strong><br />
+                                                <label className="text-xs">
+                                                    {order.highestStatusTask?.CreatedAt ? new Date(order.highestStatusTask.CreatedAt).toLocaleDateString() : ''} - {order.Remark}
+                                                </label>
+                                            </div>
+                                            <div className="items-center justify-center text-right col-end-9 col-span-1">
+                                                <label className="text-xs pr-2">
+                                                    {order.highestStatusTask?.Delivery_Date ? new Date(order.highestStatusTask.Delivery_Date).toLocaleDateString() : ''}
+                                                </label><br />
+                                                <label className="text-s text-green-500 pr-2">
+                                                    {order.highestStatusTask?.Assigned}
+                                                </label>
                                             </div>
                                         </div>
-                                    ))}
-                            </SkeletonTheme>
+                                    </div>
+                                ))
+                            )}
                         </div>
                     </main>
                 </div>
 
-                <Suspense fallback={<div className="text-center py-4">Loading...</div>}>
-                    {showOrderModal && (
-                        <div className="modal-overlay">
-                            <div className="modal-content">
-                                <AddOrder1 closeModal={closeModal} />
-                            </div>
+                {showOrderModal && (
+                    <div className="modal-overlay">
+                        <div className="modal-content">
+                            <AddOrder1 closeModal={closeModal} />
                         </div>
-                    )}
+                    </div>
+                )}
 
-                    {showEditModal && (
-                        <div className="modal-overlay fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center">
-                            <OrderUpdate order={selectedOrder} onClose={closeEditModal} />
-                        </div>
-                    )}
-                </Suspense>
+                {showEditModal && (
+                    <div className="modal-overlay fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center">
+                        <OrderUpdate order={selectedOrder} onClose={closeEditModal} />
+                    </div>
+                )}
 
             </div>
         </>


### PR DESCRIPTION
## Summary
- add reusable `LoadingSpinner` and export it for use across the app
- replace scattered spinners and skeletons with the unified component
- update modals and nav overlays for better mobile usability

## Testing
- `npm run lint` *(fails: many lint errors across repo)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894c6c77ab48322ad278eb407d609ae