### PR TITLE
feat: integrate feather icons and unify ui components

### DIFF
--- a/src/Components/Button.jsx
+++ b/src/Components/Button.jsx
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
 
+// Button component with optional Feather icons for a richer interface
+// Icons are passed as React components via leftIcon/rightIcon props
+
 const variantClasses = {
   primary:
     'bg-primary text-white hover:bg-secondary focus:ring-primary',
@@ -20,12 +23,16 @@ export default function Button({
   size = 'md',
   className = '',
   children,
+  leftIcon: LeftIcon,
+  rightIcon: RightIcon,
   ...props
 }) {
   const classes = `${variantClasses[variant]} ${sizeClasses[size]} inline-flex items-center justify-center rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${className}`;
   return (
     <button className={classes} {...props}>
+      {LeftIcon && <LeftIcon className="mr-2" aria-hidden="true" />}
       {children}
+      {RightIcon && <RightIcon className="ml-2" aria-hidden="true" />}
     </button>
   );
 }
@@ -35,4 +42,6 @@ Button.propTypes = {
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   className: PropTypes.string,
   children: PropTypes.node,
+  leftIcon: PropTypes.elementType,
+  rightIcon: PropTypes.elementType,
 };

--- a/src/Components/Card.jsx
+++ b/src/Components/Card.jsx
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
 
+// Basic container card used across the app to provide consistent styling
 export default function Card({ className = '', children, ...props }) {
   return (
     <div
-      className={`bg-white dark:bg-gray-800 rounded-xl shadow-card p-4 ${className}`}
+      className={`bg-white dark:bg-gray-800 rounded-xl shadow p-4 ${className}`}
       {...props}
     >
       {children}

--- a/src/Components/InputField.jsx
+++ b/src/Components/InputField.jsx
@@ -4,6 +4,7 @@ export default function InputField({
   label,
   type = 'text',
   className = '',
+  icon: Icon,
   ...props
 }) {
   return (
@@ -13,11 +14,16 @@ export default function InputField({
           {label}
         </label>
       )}
-      <input
-        type={type}
-        className={`w-full border border-gray-300 rounded-md p-2 shadow-sm hover:border-secondary focus:border-primary focus:ring-1 focus:ring-primary ${className}`}
-        {...props}
-      />
+      <div className="relative flex items-center">
+        {Icon && (
+          <Icon className="absolute left-3 text-gray-400" aria-hidden="true" />
+        )}
+        <input
+          type={type}
+          className={`w-full border border-gray-300 rounded-md p-2 ${Icon ? 'pl-10' : 'pl-3'} shadow-sm hover:border-secondary focus:border-primary focus:ring-1 focus:ring-primary ${className}`}
+          {...props}
+        />
+      </div>
     </div>
   );
 }
@@ -26,4 +32,5 @@ InputField.propTypes = {
   label: PropTypes.string,
   type: PropTypes.string,
   className: PropTypes.string,
+  icon: PropTypes.elementType,
 };

--- a/src/Components/LoadingSpinner.jsx
+++ b/src/Components/LoadingSpinner.jsx
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
+import { FiLoader } from 'react-icons/fi';
 
+// Simple spinner based on Feather's loader icon
 export default function LoadingSpinner({ size = 24, className = 'text-primary' }) {
   return (
-    <div
-      className={`animate-spin rounded-full border-4 border-current border-t-transparent ${className}`}
-      style={{ width: size, height: size }}
-      role="status"
+    <FiLoader
+      className={`animate-spin ${className}`}
+      size={size}
       aria-label="Loading"
     />
   );

--- a/src/Components/Modal.jsx
+++ b/src/Components/Modal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import Button from './Button';
+import { FiX } from 'react-icons/fi';
 
 export default function Modal({
   isOpen,
@@ -20,9 +21,8 @@ export default function Modal({
           className="absolute top-2 right-2 px-2 py-1"
           onClick={onClose}
           aria-label="Close"
-        >
-          ✕
-        </Button>
+          leftIcon={FiX}
+        />
       </div>
     </div>
   );

--- a/src/Components/Table.jsx
+++ b/src/Components/Table.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 
 export default function Table({ columns = [], data = [] }) {
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead className="bg-gray-50">
+    <div className="overflow-x-auto rounded-lg shadow">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <thead className="bg-gray-100">
           <tr>
             {columns.map((col) => (
               <th

--- a/src/Pages/login.jsx
+++ b/src/Pages/login.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from "react-router-dom";
-import axios from "axios";
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { Card, InputField, Button } from '../Components';
+import { FiUser, FiLock, FiLogIn } from 'react-icons/fi';
 
 export default function Login() {
     const navigate = useNavigate();
@@ -62,34 +64,31 @@ export default function Login() {
     
     return (
         <div className="flex justify-center items-center min-h-screen bg-background">
-            <div className="bg-white p-3 rounded w-90">
-                <h1>Login</h1>
+            <Card className="w-full max-w-sm">
+                <h1 className="text-xl font-semibold mb-4 text-center flex items-center justify-center"><FiUser className="mr-2" />Login</h1>
                 <form onSubmit={submit}>
-                    <div className="mb-3">
-                        <label htmlFor="Username"><strong>User Name</strong></label>
-                        <input
-                            type="text"
-                            autoComplete="off"
-                            onChange={(e) => setUser_Name(e.target.value)}
-                            placeholder="User Name"
-                            className="form-control rounded-0"
-                            required
-                        />
-                    </div>
-                    <div className="mb-3">
-                        <label htmlFor="Password"><strong>Password</strong></label>
-                        <input
-                            type="password"
-                            autoComplete="off"
-                            onChange={(e) => setPassword(e.target.value)}
-                            placeholder="Password"
-                            className="form-control rounded-0"
-                            required
-                        />
-                    </div>
-                    <button type="submit" className="w-100 h-10 bg-green-400 text-white shadow-lg flex items-center justify-center">Submit</button>
+                    <InputField
+                        label="User Name"
+                        autoComplete="off"
+                        onChange={(e) => setUser_Name(e.target.value)}
+                        placeholder="User Name"
+                        icon={FiUser}
+                        required
+                    />
+                    <InputField
+                        label="Password"
+                        type="password"
+                        autoComplete="off"
+                        onChange={(e) => setPassword(e.target.value)}
+                        placeholder="Password"
+                        icon={FiLock}
+                        required
+                    />
+                    <Button type="submit" className="w-full mt-2" rightIcon={FiLogIn}>
+                        Submit
+                    </Button>
                 </form>
-            </div>
+            </Card>
         </div>
     );
 }

--- a/src/Reports/vendorBills.jsx
+++ b/src/Reports/vendorBills.jsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from "react";
-import axios from "axios";
-import { useNavigate, useLocation } from "react-router-dom";
-import BillUpdate from "../Reports/billUpdate";
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { useNavigate, useLocation } from 'react-router-dom';
+import BillUpdate from '../Reports/billUpdate';
+import { InputField, Card, Modal } from '../Components';
+import { FiSearch } from 'react-icons/fi';
 
 export default function VendorBills() {
     const navigate = useNavigate();
@@ -69,23 +71,23 @@ export default function VendorBills() {
     return (
         <>
             <div className="pt-12 pb-20 max-w-7xl mx-auto px-4">
-                <div className="flex flex-wrap items-center bg-white w-full p-2 mb-4 rounded-lg shadow gap-2">
-                    <input
-                        type="text"
-                        placeholder="Search by Customer Name"
-                        className="form-control text-black bg-gray-100 rounded-full px-4 py-2"
+                <Card className="flex flex-wrap items-center w-full p-2 mb-4 rounded-lg shadow gap-2">
+                    <InputField
                         value={searchOrder}
                         onChange={(e) => setSearchOrder(e.target.value)}
+                        placeholder="Search by Customer Name"
+                        icon={FiSearch}
+                        className="flex-1"
                     />
-                </div>
+                </Card>
                 <main className="flex flex-1 p-4 overflow-y-auto">
                     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 w-full">
                         {filteredOrders.length > 0 ? (
                             filteredOrders.map((order, index) => (
-                                <div
+                                <Card
                                     key={index}
                                     onClick={() => handleEditClick(order)}
-                                    className="bg-white p-4 rounded-lg shadow-md hover:shadow-lg transition-all cursor-pointer"
+                                    className="p-4 hover:shadow-lg transition-all cursor-pointer"
                                 >
                                     <div className="flex justify-between items-center mb-2">
                                         <div className="font-semibold text-lg text-gray-800">
@@ -100,14 +102,14 @@ export default function VendorBills() {
                                     </div>
                                     <div className="text-sm text-gray-600 mb-2">{order.Remark}</div>
                                     <div className="flex justify-between text-sm text-gray-600">
-                                        <span>Assigned: {order.highestStatusTask?.Assigned || "N/A"}</span>
+                                        <span>Assigned: {order.highestStatusTask?.Assigned || 'N/A'}</span>
                                         <span>
                                             Delivery: {order.highestStatusTask?.Delivery_Date
                                                 ? new Date(order.highestStatusTask.Delivery_Date).toLocaleDateString()
-                                                : "N/A"}
+                                                : 'N/A'}
                                         </span>
                                     </div>
-                                </div>
+                                </Card>
                             ))
                         ) : (
                             <div className="text-center text-gray-500">No orders found</div>
@@ -115,11 +117,9 @@ export default function VendorBills() {
                     </div>
                 </main>
             </div>
-            {showEditModal && (
-                <div className="modal-overlay fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center ">
-                    <BillUpdate order={selectedOrder} onClose={closeEditModal} />
-                </div>
-            )}
+            <Modal isOpen={showEditModal} onClose={closeEditModal} title="Update Bill">
+                <BillUpdate order={selectedOrder} onClose={closeEditModal} />
+            </Modal>
         </>
     );
 }


### PR DESCRIPTION
## Summary
- add icon support to Button and InputField components
- use Feather loader and close icons for spinner and modals
- refresh login screen with new themed components and icons

## Testing
- `npm run lint` *(fails: 414 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68955e842118832292615e755c9c31aa