### PR TITLE
refactor: integrate material ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,12 @@
     "react-toastify": "^11.0.5",
     "socket.io-client": "^4.8.1",
     "whatsapp-web.js": "^1.28.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "@mui/material": "^5.15.14",
+    "@mui/icons-material": "^5.15.14",
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "@mui/x-data-grid": "^6.20.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { useEffect } from 'react';
-import 'bootstrap/dist/css/bootstrap.min.css';
 import axios from 'axios';
 import Layout from './Pages/Layout';
 import { initVersionChecker } from './utils/versionChecker';

--- a/src/Components/Button.jsx
+++ b/src/Components/Button.jsx
@@ -1,22 +1,8 @@
 import PropTypes from 'prop-types';
+import MuiButton from '@mui/material/Button';
 
-// Button component with optional Feather icons for a richer interface
-// Icons are passed as React components via leftIcon/rightIcon props
-
-const variantClasses = {
-  primary:
-    'bg-primary text-white hover:bg-secondary focus:ring-primary',
-  secondary:
-    'bg-secondary text-white hover:bg-primary focus:ring-secondary',
-  danger:
-    'bg-accent text-white hover:bg-red-600 focus:ring-accent',
-};
-
-const sizeClasses = {
-  sm: 'px-3 py-1 text-sm',
-  md: 'px-4 py-2 text-base',
-  lg: 'px-6 py-3 text-lg',
-};
+const sizeMap = { sm: 'small', md: 'medium', lg: 'large' };
+const colorMap = { primary: 'primary', secondary: 'secondary', danger: 'error' };
 
 export default function Button({
   variant = 'primary',
@@ -28,13 +14,19 @@ export default function Button({
   fullWidth = false,
   ...props
 }) {
-  const classes = `${variantClasses[variant]} ${sizeClasses[size]} inline-flex items-center justify-center rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${fullWidth ? 'w-full' : ''} ${className}`;
   return (
-    <button className={classes} {...props}>
-      {LeftIcon && <LeftIcon className="mr-2" aria-hidden="true" />}
+    <MuiButton
+      variant="contained"
+      color={colorMap[variant] || 'primary'}
+      size={sizeMap[size] || 'medium'}
+      className={className}
+      startIcon={LeftIcon ? <LeftIcon aria-hidden="true" /> : undefined}
+      endIcon={RightIcon ? <RightIcon aria-hidden="true" /> : undefined}
+      fullWidth={fullWidth}
+      {...props}
+    >
       {children}
-      {RightIcon && <RightIcon className="ml-2" aria-hidden="true" />}
-    </button>
+    </MuiButton>
   );
 }
 

--- a/src/Components/Card.jsx
+++ b/src/Components/Card.jsx
@@ -1,14 +1,12 @@
 import PropTypes from 'prop-types';
+import MuiCard from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
 
-// Basic container card used across the app to provide consistent styling
 export default function Card({ className = '', children, ...props }) {
   return (
-    <div
-      className={`bg-white dark:bg-gray-800 rounded-xl shadow p-4 ${className}`}
-      {...props}
-    >
-      {children}
-    </div>
+    <MuiCard className={className} {...props}>
+      <CardContent>{children}</CardContent>
+    </MuiCard>
   );
 }
 

--- a/src/Components/InputField.jsx
+++ b/src/Components/InputField.jsx
@@ -1,4 +1,6 @@
 import PropTypes from 'prop-types';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 export default function InputField({
   label,
@@ -8,23 +10,24 @@ export default function InputField({
   ...props
 }) {
   return (
-    <div className="mb-4 w-full">
-      {label && (
-        <label className="block text-sm font-medium text-text mb-1">
-          {label}
-        </label>
-      )}
-      <div className="relative flex items-center">
-        {Icon && (
-          <Icon className="absolute left-3 text-gray-400" aria-hidden="true" />
-        )}
-        <input
-          type={type}
-          className={`w-full border border-gray-300 rounded-md p-2 ${Icon ? 'pl-10' : 'pl-3'} shadow-sm hover:border-secondary focus:border-primary focus:ring-1 focus:ring-primary ${className}`}
-          {...props}
-        />
-      </div>
-    </div>
+    <TextField
+      label={label}
+      type={type}
+      fullWidth
+      className={className}
+      InputProps={
+        Icon
+          ? {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Icon aria-hidden="true" />
+                </InputAdornment>
+              ),
+            }
+          : undefined
+      }
+      {...props}
+    />
   );
 }
 

--- a/src/Components/LoadingSpinner.jsx
+++ b/src/Components/LoadingSpinner.jsx
@@ -1,15 +1,8 @@
 import PropTypes from 'prop-types';
-import { FiLoader } from 'react-icons/fi';
+import CircularProgress from '@mui/material/CircularProgress';
 
-// Simple spinner based on Feather's loader icon
-export default function LoadingSpinner({ size = 24, className = 'text-primary' }) {
-  return (
-    <FiLoader
-      className={`animate-spin ${className}`}
-      size={size}
-      aria-label="Loading"
-    />
-  );
+export default function LoadingSpinner({ size = 24, className = '' }) {
+  return <CircularProgress size={size} className={className} />;
 }
 
 LoadingSpinner.propTypes = {

--- a/src/Components/Modal.jsx
+++ b/src/Components/Modal.jsx
@@ -1,5 +1,11 @@
 import PropTypes from 'prop-types';
-import Button from './Button';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+} from '@mui/material';
 import { FiX } from 'react-icons/fi';
 
 export default function Modal({
@@ -9,22 +15,23 @@ export default function Modal({
   children,
   actions,
 }) {
-  if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 w-full max-w-md mx-4 relative max-h-[90vh] overflow-y-auto">
-        {title && <h2 className="text-lg font-semibold mb-4">{title}</h2>}
-        <div>{children}</div>
-        {actions && <div className="mt-4 flex justify-end space-x-2">{actions}</div>}
-        <Button
-          variant="secondary"
-          className="absolute top-2 right-2 px-2 py-1"
-          onClick={onClose}
-          aria-label="Close"
-          leftIcon={FiX}
-        />
-      </div>
-    </div>
+    <Dialog open={isOpen} onClose={onClose} fullWidth maxWidth="sm">
+      {title && (
+        <DialogTitle sx={{ m: 0, p: 2 }}>
+          {title}
+          <IconButton
+            aria-label="Close"
+            onClick={onClose}
+            sx={{ position: 'absolute', right: 8, top: 8 }}
+          >
+            <FiX />
+          </IconButton>
+        </DialogTitle>
+      )}
+      <DialogContent dividers>{children}</DialogContent>
+      {actions && <DialogActions>{actions}</DialogActions>}
+    </Dialog>
   );
 }
 

--- a/src/Components/Table.jsx
+++ b/src/Components/Table.jsx
@@ -1,34 +1,36 @@
 import PropTypes from 'prop-types';
+import {
+  Table as MuiTable,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from '@mui/material';
 
 export default function Table({ columns = [], data = [] }) {
   return (
-    <div className="overflow-x-auto rounded-lg shadow">
-      <table className="min-w-full divide-y divide-gray-200 text-sm">
-        <thead className="bg-gray-100">
-          <tr>
+    <TableContainer component={Paper}>
+      <MuiTable size="small">
+        <TableHead>
+          <TableRow>
             {columns.map((col) => (
-              <th
-                key={col.accessor}
-                className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-              >
-                {col.Header}
-              </th>
+              <TableCell key={col.accessor}>{col.Header}</TableCell>
             ))}
-          </tr>
-        </thead>
-        <tbody className="bg-white divide-y divide-gray-200">
+          </TableRow>
+        </TableHead>
+        <TableBody>
           {data.map((row, idx) => (
-            <tr key={idx} className="hover:bg-gray-50">
+            <TableRow key={idx} hover>
               {columns.map((col) => (
-                <td key={col.accessor} className="px-4 py-2 whitespace-nowrap">
-                  {row[col.accessor]}
-                </td>
+                <TableCell key={col.accessor}>{row[col.accessor]}</TableCell>
               ))}
-            </tr>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
-    </div>
+        </TableBody>
+      </MuiTable>
+    </TableContainer>
   );
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import { ThemeProvider, CssBaseline } from '@mui/material'
+import { lightTheme } from './theme.js'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ThemeProvider theme={lightTheme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -16,6 +16,3 @@ export const darkTheme = createTheme({
   ...baseOptions,
   palette: { ...baseOptions.palette, mode: 'dark' },
 });
-
-export default { lightTheme, darkTheme };
-

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,23 +1,21 @@
-export const lightTheme = {
-  colors: {
-    primary: '#1E88E5',
-    secondary: '#1565C0',
-    accent: '#E53935',
-    background: '#F4F6F8',
-    text: '#212121',
+import { createTheme } from '@mui/material/styles';
+
+const baseOptions = {
+  typography: { fontFamily: 'Inter, Roboto, sans-serif' },
+  palette: {
+    primary: { main: '#1976d2' },
   },
-  fontFamily: 'Inter, Roboto, sans-serif',
 };
 
-export const darkTheme = {
-  colors: {
-    primary: '#1E88E5',
-    secondary: '#1565C0',
-    accent: '#E53935',
-    background: '#1F2937',
-    text: '#F8FAFC',
-  },
-  fontFamily: 'Inter, Roboto, sans-serif',
-};
+export const lightTheme = createTheme({
+  ...baseOptions,
+  palette: { ...baseOptions.palette, mode: 'light' },
+});
+
+export const darkTheme = createTheme({
+  ...baseOptions,
+  palette: { ...baseOptions.palette, mode: 'dark' },
+});
 
 export default { lightTheme, darkTheme };
+


### PR DESCRIPTION
## Summary
- install Material UI dependencies and introduce light/dark theme
- wrap application with MUI ThemeProvider and CssBaseline
- refactor core UI components (Button, InputField, Card, Table, Modal, LoadingSpinner) to use MUI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: PropTypes and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895eb25ee0083229af578f2692abeff