### PR TITLE
feat: add dashboard home page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ import Register from "./Pages/Register";
 import Planner from "./Pages/Planner";
 import Review from "./Pages/Review";
 import Team from "./Pages/Team";
-import Home from './Pages/home';
+import Dashboard from './Pages/Dashboard';
 import AddCustomer from "./Pages/addCustomer";
 import AddCustGroup from "./Pages/addCustomergroup";
 import AddUser from "./Pages/addUser";
@@ -99,7 +99,7 @@ function App() {
             <Route path="/planner" element={<Planner />} />
             <Route path="/review" element={<Review />} />
             <Route path="/team" element={<Team />} />
-            <Route path="/home" element={<Home />} />
+            <Route path="/home" element={<Dashboard />} />
             <Route path="/adminHome" element={<AdminHome />} />
             <Route path="/vendorHome" element={<VendorHome />} />
             <Route path="/addCustomer" element={<AddCustomer />} />

--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+
+// Simple card component used on the dashboard
+function StatCard({ label, value, onClick }) {
+  return (
+    <div
+      onClick={onClick}
+      className="p-4 bg-white rounded shadow cursor-pointer hover:shadow-md transition-shadow"
+    >
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="mt-2 text-2xl font-semibold">{value ?? 0}</p>
+    </div>
+  );
+}
+
+export default function Dashboard() {
+  const navigate = useNavigate();
+  const [period, setPeriod] = useState('today'); // 'today' | 'week' | 'month'
+  const [stats, setStats] = useState({ today: {}, week: {}, month: {} });
+
+  // Fetch statistics whenever the period changes
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await axios.get(`/dashboard/${period}`);
+        setStats((prev) => ({ ...prev, [period]: response.data }));
+      } catch (err) {
+        // In case the endpoint is missing or fails we just log the error.
+        console.error('Failed to load dashboard stats', err);
+      }
+    };
+    fetchStats();
+  }, [period]);
+
+  const current = stats[period];
+
+  // Definition of dashboard cards and their navigation targets
+  const cards = [
+    { key: 'collection', label: "Today's Collection", route: '/allTransaction' },
+    { key: 'receivable', label: "Today's Receivable", route: '/addRecievable' },
+    { key: 'newOrders', label: 'New Orders Today', route: '/allOrder' },
+    { key: 'completedOrders', label: 'Completed Orders Today', route: '/allOrder' },
+    { key: 'attendance', label: "Employees Attendance", route: '/AllAttandance' },
+    { key: 'followups', label: "Today's Follow-ups", route: '/addUsertask' },
+    { key: 'enquiries', label: 'New Enquiries', route: '/addEnquiry' },
+    { key: 'targets', label: 'Target Achievements', route: '/taskReport' }
+  ];
+
+  return (
+    <div className="p-4">
+      {/* Period selector */}
+      <div className="flex space-x-2 mb-4">
+        {['today', 'week', 'month'].map((p) => (
+          <button
+            key={p}
+            onClick={() => setPeriod(p)}
+            className={`px-3 py-1 rounded ${
+              period === p ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'
+            }`}
+          >
+            {p === 'today' ? 'Today' : p === 'week' ? 'Week' : 'Month'}
+          </button>
+        ))}
+      </div>
+
+      {/* Statistics cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {cards.map((card) => (
+          <StatCard
+            key={card.key}
+            label={card.label}
+            value={current[card.key]}
+            onClick={() => navigate(card.route)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create dashboard page with period toggle and stat cards
- route `/home` to the new dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 407 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d8f72fec83229a34b7a559ef8334