### PR TITLE
Unify modal UI across forms

### DIFF
--- a/src/Pages/AddTransaction.jsx
+++ b/src/Pages/AddTransaction.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
-import { Button, InputField, Card, ToastContainer, toast, LoadingSpinner } from "../Components";
+import { Button, InputField, ToastContainer, toast, LoadingSpinner } from "../Components";
 import InvoiceModal from "../Components/InvoiceModal";
 
 export default function AddTransaction({ editMode, existingData, onClose, onSuccess }) {
@@ -184,13 +184,16 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
   const addCustomer = () => navigate("/addCustomer");
 
   return (
-    <div className="flex items-center justify-center  bg-secondary min-h-screen p-4">
-      
+    <>
       <ToastContainer />
 
       <InvoiceModal
-        isOpen={showInvoiceModal}
-        onClose={() => { setShowInvoiceModal(false); onSuccess?.(); onClose?.(); }}
+        open={showInvoiceModal}
+        onClose={() => {
+          setShowInvoiceModal(false);
+          onSuccess?.();
+          onClose?.();
+        }}
         invoiceRef={previewRef}
         customerName={Customer_name}
         customerMobile={mobileToSend}
@@ -199,14 +202,21 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
         onSendWhatsApp={sendWhatsApp}
       />
 
-      <Card className="relative">
-        <button onClick={closeModal} className="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-2 px-2 py-0">
-          ✕
-        </button>
+      <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+        <div className="bg-white w-full max-w-2xl rounded-xl shadow-xl p-6 relative">
+          <button
+            onClick={closeModal}
+            className="absolute right-2 top-2 text-xl text-gray-400 hover:text-green-500"
+            type="button"
+          >
+            ×
+          </button>
 
-        <h2 className="text-xl font-semibold mb-4">{editMode ? "Edit Receipt" : "Add Receipt"}</h2>
+          <h2 className="text-xl font-semibold mb-4 text-center">
+            {editMode ? "Edit Receipt" : "Add Receipt"}
+          </h2>
 
-        <form onSubmit={submit}>
+          <form onSubmit={submit} className="space-y-4">
           {optionsLoading ? (
             <div className="flex justify-center items-center h-12 mb-4">
               <LoadingSpinner />
@@ -330,8 +340,9 @@ export default function AddTransaction({ editMode, existingData, onClose, onSucc
             )}
           </Button>
         </form>
-      </Card>
-    </div>
+      </div>
+      </div>
+    </>
   );
 }
 

--- a/src/Pages/OrderUpdate.jsx
+++ b/src/Pages/OrderUpdate.jsx
@@ -1,5 +1,6 @@
+/* eslint-disable react/prop-types */
 // src/Pages/OrderUpdate.jsx
-import React, { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 

--- a/src/Pages/OrderUpdate.jsx
+++ b/src/Pages/OrderUpdate.jsx
@@ -230,170 +230,172 @@ export default function OrderUpdate({ order = {}, onClose = () => {} }) {
   const closeInvoice = () => setShowInvoice(false);
 
   return (
-    <div className="">
-      <button
-        className="absolute right-2 top-2 text-xl text-gray-400 hover:text-green-500"
-        onClick={onClose}
-        type="button"
-        aria-label="Close"
-      >
-        ×
-      </button>
+    <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+      <div className="bg-white w-full max-w-3xl rounded-xl shadow-xl p-6 relative">
+        <button
+          className="absolute right-2 top-2 text-xl text-gray-400 hover:text-green-500"
+          onClick={onClose}
+          type="button"
+          aria-label="Close"
+        >
+          ×
+        </button>
 
-      {/* Header */}
-      <OrderHeader values={values} notes={notes} />
+        {/* Header */}
+        <OrderHeader values={values} notes={notes} />
 
-      {/* Item Remarks (from Items[].Remark) */}
-      {itemRemarks.length > 0 && (
-        <div className="mt-3 mb-4">
-          
-          <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1">
-            {itemRemarks.map((r, i) => (
-              <li key={i}>
-                <span className="font-medium">{r.itemName}:</span> {r.remark}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+        {/* Item Remarks (from Items[].Remark) */}
+        {itemRemarks.length > 0 && (
+          <div className="mt-3 mb-4">
 
-      {/* Status Table */}
-      <StatusTable status={values.Status} />
-
-      {/* Update Form */}
-      <form onSubmit={handleSaveChanges} className="space-y-4">
-        <div>
-          <label className="block font-medium text-gray-700 mb-1">Update Job Status</label>
-          <select
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
-            value={values.Task}
-            onChange={(e) => handleChangeTask(e.target.value)}
-          >
-            <option value="">Select Task</option>
-            {taskOptions.map((option, i) => (
-              <option key={i} value={option}>
-                {option}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label className="block font-medium text-gray-700 mb-1">Assign User</label>
-          <select
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
-            value={values.Assigned}
-            onChange={(e) => setValues({ ...values, Assigned: e.target.value })}
-            disabled={!values.Task}
-          >
-            <option value="">Select User</option>
-            {(userOptions[values.Task] || []).map((user, i) => (
-              <option key={i} value={user}>
-                {user}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            id="advanceCheckbox"
-            checked={isAdvanceChecked}
-            onChange={handleAdvanceCheckboxChange}
-            className="h-4 w-4 text-[#25d366] focus:ring-[#25d366] border-gray-300 rounded"
-          />
-          <label htmlFor="advanceCheckbox" className="text-gray-700">
-            Update Date
-          </label>
-        </div>
-
-        {isAdvanceChecked && (
-          <div>
-            <label className="block font-medium text-gray-700 mb-1">Delivery Date</label>
-            <input
-              type="date"
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
-              value={values.Delivery_Date}
-              onChange={(e) => setValues({ ...values, Delivery_Date: e.target.value })}
-            />
+            <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1">
+              {itemRemarks.map((r, i) => (
+                <li key={i}>
+                  <span className="font-medium">{r.itemName}:</span> {r.remark}
+                </li>
+              ))}
+            </ul>
           </div>
         )}
 
-        {/* Steps (Task Groups) — ONLY Id === 1, and NOT pre-selected */}
-        <div>
-          <label className="block mb-1 font-medium">Steps</label>
-          <div className="flex flex-wrap gap-2">
-            {taskGroups
-              .filter((tg) => tg.Id === 1)
-              .map((tg) => {
-                const name = tg.Task_group_name || tg.Task_group || "Unnamed Group";
-                const uuid = tg.Task_group_uuid;
-                const checked = selectedTaskGroups.includes(uuid);
-                const loading = !!busyStep[uuid];
+        {/* Status Table */}
+        <StatusTable status={values.Status} />
 
-                return (
-                  <label
-                    key={uuid}
-                    className={`flex items-center gap-2 border px-2 py-1 rounded-md shadow-sm ${
-                      loading ? "opacity-60 cursor-not-allowed" : ""
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={() => !loading && toggleStep(tg)}
-                      className="accent-[#25D366]"
-                      disabled={loading}
-                    />
-                    <span>{name}</span>
-                  </label>
-                );
-              })}
+        {/* Update Form */}
+        <form onSubmit={handleSaveChanges} className="space-y-4">
+          <div>
+            <label className="block font-medium text-gray-700 mb-1">Update Job Status</label>
+            <select
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+              value={values.Task}
+              onChange={(e) => handleChangeTask(e.target.value)}
+            >
+              <option value="">Select Task</option>
+              {taskOptions.map((option, i) => (
+                <option key={i} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
           </div>
-          <p className="text-xs text-gray-500 mt-1">
-            Checking/unchecking updates the order immediately.
-          </p>
-        </div>
 
-        <div className="flex gap-2">
-          <button
-            type="submit"
-            disabled={!canSubmit}
-            className={`flex-1 text-white font-medium py-2 rounded-lg transition ${
-              canSubmit ? "bg-[#25d366] hover:bg-[#128c7e]" : "bg-gray-300 cursor-not-allowed"
-            }`}
-          >
-            Update Status
-          </button>
+          <div>
+            <label className="block font-medium text-gray-700 mb-1">Assign User</label>
+            <select
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+              value={values.Assigned}
+              onChange={(e) => setValues({ ...values, Assigned: e.target.value })}
+              disabled={!values.Task}
+            >
+              <option value="">Select User</option>
+              {(userOptions[values.Task] || []).map((user, i) => (
+                <option key={i} value={user}>
+                  {user}
+                </option>
+              ))}
+            </select>
+          </div>
 
-          {/* Preview Invoice button */}
-          <button
-            type="button"
-            onClick={openInvoice}
-            className="flex-1 border border-gray-300 hover:border-[#25d366] text-gray-700 hover:text-[#128c7e] font-medium py-2 rounded-lg transition"
-          >
-            Preview Invoice
-          </button>
-        </div>
-      </form>
+          <div className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              id="advanceCheckbox"
+              checked={isAdvanceChecked}
+              onChange={handleAdvanceCheckboxChange}
+              className="h-4 w-4 text-[#25d366] focus:ring-[#25d366] border-gray-300 rounded"
+            />
+            <label htmlFor="advanceCheckbox" className="text-gray-700">
+              Update Date
+            </label>
+          </div>
 
-      {/* Invoice Modal */}
-      <InvoiceModal open={showInvoice} onClose={closeInvoice}>
-        <InvoicePreview
-          order={{
-            ...order,
-            // keep latest values overrides
-            Status: values.Status,
-            Items: values.Items,
-            Customer_name: values.Customer_name,
-            Order_Number: values.Order_Number,
-            Order_uuid: values.Order_uuid,
-            Customer_uuid: values.Customer_uuid,
-          }}
-          onClose={closeInvoice}
-        />
-      </InvoiceModal>
+          {isAdvanceChecked && (
+            <div>
+              <label className="block font-medium text-gray-700 mb-1">Delivery Date</label>
+              <input
+                type="date"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                value={values.Delivery_Date}
+                onChange={(e) => setValues({ ...values, Delivery_Date: e.target.value })}
+              />
+            </div>
+          )}
+
+          {/* Steps (Task Groups) — ONLY Id === 1, and NOT pre-selected */}
+          <div>
+            <label className="block mb-1 font-medium">Steps</label>
+            <div className="flex flex-wrap gap-2">
+              {taskGroups
+                .filter((tg) => tg.Id === 1)
+                .map((tg) => {
+                  const name = tg.Task_group_name || tg.Task_group || "Unnamed Group";
+                  const uuid = tg.Task_group_uuid;
+                  const checked = selectedTaskGroups.includes(uuid);
+                  const loading = !!busyStep[uuid];
+
+                  return (
+                    <label
+                      key={uuid}
+                      className={`flex items-center gap-2 border px-2 py-1 rounded-md shadow-sm ${
+                        loading ? "opacity-60 cursor-not-allowed" : ""
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => !loading && toggleStep(tg)}
+                        className="accent-[#25D366]"
+                        disabled={loading}
+                      />
+                      <span>{name}</span>
+                    </label>
+                  );
+                })}
+            </div>
+            <p className="text-xs text-gray-500 mt-1">
+              Checking/unchecking updates the order immediately.
+            </p>
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className={`flex-1 text-white font-medium py-2 rounded-lg transition ${
+                canSubmit ? "bg-[#25d366] hover:bg-[#128c7e]" : "bg-gray-300 cursor-not-allowed"
+              }`}
+            >
+              Update Status
+            </button>
+
+            {/* Preview Invoice button */}
+            <button
+              type="button"
+              onClick={openInvoice}
+              className="flex-1 border border-gray-300 hover:border-[#25d366] text-gray-700 hover:text-[#128c7e] font-medium py-2 rounded-lg transition"
+            >
+              Preview Invoice
+            </button>
+          </div>
+        </form>
+
+        {/* Invoice Modal */}
+        <InvoiceModal open={showInvoice} onClose={closeInvoice}>
+          <InvoicePreview
+            order={{
+              ...order,
+              // keep latest values overrides
+              Status: values.Status,
+              Items: values.Items,
+              Customer_name: values.Customer_name,
+              Order_Number: values.Order_Number,
+              Order_uuid: values.Order_uuid,
+              Customer_uuid: values.Customer_uuid,
+            }}
+            onClose={closeInvoice}
+          />
+        </InvoiceModal>
+      </div>
     </div>
   );
 }

--- a/src/Pages/addCustomer.jsx
+++ b/src/Pages/addCustomer.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+/* eslint-disable react/prop-types */
+import { useEffect, useState } from 'react';
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 

--- a/src/Pages/addCustomer.jsx
+++ b/src/Pages/addCustomer.jsx
@@ -104,10 +104,18 @@ export default function AddCustomer({ onClose }) {
         else navigate("/home");
     };
 
-    const content = (
-        <div className="bg-white p-6 rounded-xl shadow-xl w-full max-w-[90vw] max-h-[90vh] overflow-y-auto">
-            <h2 className="text-2xl font-semibold text-green-600 mb-4 text-center">Add Customer</h2>
-            <form onSubmit={handleSubmit} className="space-y-4">
+    return (
+        <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+            <div className="bg-white p-6 rounded-xl shadow-xl w-full max-w-[90vw] max-h-[90vh] overflow-y-auto relative">
+                <button
+                    onClick={handleCancel}
+                    className="absolute right-2 top-2 text-xl text-gray-400 hover:text-green-500"
+                    type="button"
+                >
+                    ×
+                </button>
+                <h2 className="text-2xl font-semibold text-green-600 mb-4 text-center">Add Customer</h2>
+                <form onSubmit={handleSubmit} className="space-y-4">
 
                     {/* Customer Name */}
                     <div>
@@ -216,15 +224,8 @@ export default function AddCustomer({ onClose }) {
                     Cancel
                 </button>
             </div>
-        </form>
-        </div>
-    );
-
-    if (onClose) return content;
-
-    return (
-        <div className="flex justify-center items-center bg-[#eae6df] min-h-screen">
-            {content}
+                </form>
+            </div>
         </div>
     );
 }

--- a/src/Pages/addItem.jsx
+++ b/src/Pages/addItem.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 

--- a/src/Pages/addItem.jsx
+++ b/src/Pages/addItem.jsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import { useNavigate } from "react-router-dom";
-import axios from "axios"
+import axios from "axios";
 
 export default function AddItem() {
     const navigate = useNavigate();
@@ -53,36 +53,56 @@ export default function AddItem() {
      };
 
     return (
-        <div className="d-flex justify-content-center align-items-center bg-secondary vh-100">
-           
-            <div className="bg-white p-3 rounded w-90">
-            <h2>Add Item</h2>
+        <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+            <div className="bg-white w-full max-w-md rounded-xl shadow-xl p-6 relative">
+                <button
+                    onClick={closeModal}
+                    className="absolute right-2 top-2 text-xl text-gray-400 hover:text-green-500"
+                    type="button"
+                >
+                    ×
+                </button>
+                <h2 className="text-xl font-semibold mb-4 text-center">Add Item</h2>
 
-            <form action="POST">
-                <div className="mb-3">
-                    <label htmlFor="Itemname"><strong>Item Name</strong></label>
-                <input type="Itemname" autoComplete="off" onChange={(e) => { setItem_Name(e.target.value) }} placeholder="Item Name" className="form-control rounded-0" />
-                </div>              
-                <div className="mb-3">
-                <label htmlFor="Itemgroup"><strong>Item Group</strong></label>
-                <select className="form-control rounded-0" onChange={(e) => setItem_Group(e.target.value)} value={Item_group}>
+                <form action="POST" className="space-y-4">
+                    <div>
+                        <label htmlFor="Itemname" className="block font-medium text-gray-700 mb-1">Item Name</label>
+                        <input
+                            type="text"
+                            autoComplete="off"
+                            onChange={(e) => { setItem_Name(e.target.value) }}
+                            placeholder="Item Name"
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                        />
+                    </div>
+                    <div>
+                        <label htmlFor="Itemgroup" className="block font-medium text-gray-700 mb-1">Item Group</label>
+                        <select
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                            onChange={(e) => setItem_Group(e.target.value)}
+                            value={Item_group}
+                        >
                             <option value="">Select Group</option>
-                           
-                               { groupOptions.map((option, index) => (
-                                    <option key={index} value={option}>{option}</option>
-                                ))
-                            }
+                            {groupOptions.map((option, index) => (
+                                <option key={index} value={option}>{option}</option>
+                            ))}
                         </select>
-                </div>
-                <button type="submit" onClick={submit} className="w-100 h-10 bg-green-500 text-white shadow-lg flex items-center justify-center"> Submit </button>
-                <button 
-                        type="button" 
-                        className="w-100 h-10 bg-red-500 text-white shadow-lg flex items-center justify-center"
+                    </div>
+                    <button
+                        type="submit"
+                        onClick={submit}
+                        className="w-full bg-[#25d366] hover:bg-[#128c7e] text-white font-medium py-2 rounded-lg transition"
+                    >
+                        Submit
+                    </button>
+                    <button
+                        type="button"
+                        className="w-full bg-gray-400 hover:bg-gray-600 text-white font-medium py-2 rounded-lg transition"
                         onClick={closeModal}
                     >
                         Close
                     </button>
-            </form>
+                </form>
             </div>
         </div>
     );

--- a/src/Pages/addOrder1.jsx
+++ b/src/Pages/addOrder1.jsx
@@ -447,11 +447,7 @@ export default function AddOrder1() {
         </div>
       </div>
 
-      {showCustomerModal && (
-        <div className="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
-          <AddCustomer onClose={exitModal} />
-        </div>
-      )}
+      {showCustomerModal && <AddCustomer onClose={exitModal} />}
     </>
   );
 }

--- a/src/Pages/addTransaction1.jsx
+++ b/src/Pages/addTransaction1.jsx
@@ -3,7 +3,6 @@ import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 import toast, { Toaster } from "react-hot-toast";
-import 'bootstrap/dist/css/bootstrap.min.css';
 import InvoiceModal from "../Components/InvoiceModal";
 import { LoadingSpinner } from "../Components";
 
@@ -162,11 +161,11 @@ export default function AddTransaction1() {
   };
 
   return (
-    <div className="d-flex justify-content-center align-items-center bg-secondary vh-100">
+    <>
       <Toaster position="top-center" reverseOrder={false} />
 
       <InvoiceModal
-        isOpen={showInvoiceModal}
+        open={showInvoiceModal}
         onClose={() => setShowInvoiceModal(false)}
         invoiceRef={previewRef}
         customerName={Customer_name}
@@ -176,118 +175,154 @@ export default function AddTransaction1() {
         onSendWhatsApp={sendWhatsApp}
       />
 
-      <div className="bg-white p-3 rounded w-90 position-relative">
-        <button onClick={closeModal} className="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-2 px-2 py-0">
-          ✕
-        </button>
+      <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+        <div className="bg-white w-full max-w-2xl rounded-xl shadow-xl p-6 relative">
+          <button
+            onClick={closeModal}
+            className="absolute right-2 top-2 text-xl text-gray-400 hover:text-green-500"
+            type="button"
+          >
+            ×
+          </button>
 
-        <h2>Add Payment</h2>
+          <h2 className="text-xl font-semibold mb-4 text-center">Add Payment</h2>
 
-        <form onSubmit={submit}>
-          {optionsLoading ? (
-            <div className="d-flex justify-content-center align-items-center mb-3" style={{ height: '38px' }}>
-              <LoadingSpinner />
-            </div>
-          ) : (
-            <div className="mb-3 position-relative">
+          <form onSubmit={submit} className="space-y-4">
+            {optionsLoading ? (
+              <div className="flex justify-center items-center h-10">
+                <LoadingSpinner />
+              </div>
+            ) : (
+              <div className="relative">
+                <input
+                  type="text"
+                  placeholder="Search by Customer Name"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                  value={Customer_name}
+                  onChange={handleInputChange}
+                  onFocus={() => setShowOptions(true)}
+                />
+                {showOptions && filteredOptions.length > 0 && (
+                  <ul className="absolute z-10 w-full bg-white border rounded-md max-h-40 overflow-y-auto">
+                    {filteredOptions.map((option, index) => (
+                      <li
+                        key={index}
+                        className="p-2 hover:bg-gray-100 cursor-pointer"
+                        onClick={() => handleOptionClick(option)}
+                      >
+                        {option.Customer_name}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            <button
+              onClick={addCustomer}
+              type="button"
+              className="bg-[#25D366] text-white w-8 h-8 rounded-full flex items-center justify-center"
+            >
+              +
+            </button>
+
+            <div>
+              <label className="block font-medium text-gray-700 mb-1">Description</label>
               <input
                 type="text"
-                placeholder="Search by Customer Name"
-                className="form-control mb-3"
-                value={Customer_name}
-                onChange={handleInputChange}
-                onFocus={() => setShowOptions(true)}
+                value={Description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                placeholder="Description"
               />
-              {showOptions && filteredOptions.length > 0 && (
-                <ul className="list-group position-absolute w-100 z-10">
-                  {filteredOptions.map((option, index) => (
-                    <li key={index} className="list-group-item list-group-item-action"
-                      onClick={() => handleOptionClick(option)}>
-                      {option.Customer_name}
-                    </li>
-                  ))}
-                </ul>
-              )}
             </div>
-          )}
 
-          <button onClick={addCustomer} type="button" className="btn btn-primary mb-3">
-            Add Customer
-          </button>
-
-          <div className="mb-3">
-            <label><strong>Description</strong></label>
-            <input
-              type="text"
-              value={Description}
-              onChange={(e) => setDescription(e.target.value)}
-              className="form-control"
-              placeholder="Description"
-            />
-          </div>
-
-          <div className="mb-3">
-            <label><strong>Amount</strong></label>
-            <input
-              type="number"
-              value={Amount}
-              onChange={handleAmountChange}
-              className="form-control"
-              placeholder="Amount"
-            />
-          </div>
-
-          {optionsLoading ? (
-            <div className="d-flex justify-content-center align-items-center mb-3" style={{ height: '38px' }}>
-              <LoadingSpinner />
-            </div>
-          ) : (
-            <div className="mb-3">
-              <label><strong>Payment Mode</strong></label>
-              <select
-                value={DebitCustomer}
-                onChange={(e) => setDebitCustomer(e.target.value)}
-                className="form-control"
-                required
-              >
-                <option value="">Select Payment</option>
-                {accountCustomerOptions.map((cust, i) => (
-                  <option key={i} value={cust.Customer_uuid}>
-                    {cust.Customer_name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          <input type="file" accept="image/*" onChange={handleFileChange} className="form-control mb-3" />
-
-          <div className="mb-3 form-check">
-            <input type="checkbox" className="form-check-input" checked={isDateChecked} onChange={handleDateCheckboxChange} />
-            <label className="form-check-label">Save Date</label>
-          </div>
-
-          {isDateChecked && (
-            <div className="mb-3">
-              <label><strong>Date</strong></label>
+            <div>
+              <label className="block font-medium text-gray-700 mb-1">Amount</label>
               <input
-                type="date"
-                value={Transaction_date}
-                onChange={(e) => setTransaction_date(e.target.value)}
-                className="form-control"
+                type="number"
+                value={Amount}
+                onChange={handleAmountChange}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                placeholder="Amount"
               />
             </div>
-          )}
 
-          <button
-            type="submit"
-            className="btn btn-success w-100"
-            disabled={loading || !Amount || isNaN(Amount) || Amount <= 0 || !CreditCustomer || !DebitCustomer}
-          >
-            {loading ? <><LoadingSpinner size={16} className="me-2" /> Saving...</> : "Submit"}
-          </button>
-        </form>
+            {optionsLoading ? (
+              <div className="flex justify-center items-center h-10">
+                <LoadingSpinner />
+              </div>
+            ) : (
+              <div>
+                <label className="block font-medium text-gray-700 mb-1">Payment Mode</label>
+                <select
+                  value={DebitCustomer}
+                  onChange={(e) => setDebitCustomer(e.target.value)}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                  required
+                >
+                  <option value="">Select Payment</option>
+                  {accountCustomerOptions.map((cust, i) => (
+                    <option key={i} value={cust.Customer_uuid}>
+                      {cust.Customer_name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
+              className="w-full border border-gray-300 rounded-lg p-2"
+            />
+
+            <div className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={isDateChecked}
+                onChange={handleDateCheckboxChange}
+                className="h-4 w-4 text-[#25d366] border-gray-300 rounded"
+              />
+              <label className="text-gray-700">Save Date</label>
+            </div>
+
+            {isDateChecked && (
+              <div>
+                <label className="block font-medium text-gray-700 mb-1">Date</label>
+                <input
+                  type="date"
+                  value={Transaction_date}
+                  onChange={(e) => setTransaction_date(e.target.value)}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                />
+              </div>
+            )}
+
+            <button
+              type="submit"
+              className="w-full bg-[#25d366] hover:bg-[#128c7e] text-white font-medium py-2 rounded-lg transition"
+              disabled={
+                loading ||
+                !Amount ||
+                isNaN(Amount) ||
+                Amount <= 0 ||
+                !CreditCustomer ||
+                !DebitCustomer
+              }
+            >
+              {loading ? (
+                <>
+                  <LoadingSpinner size={16} className="mr-2" /> Saving...
+                </>
+              ) : (
+                "Submit"
+              )}
+            </button>
+          </form>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/Pages/addTransaction1.jsx
+++ b/src/Pages/addTransaction1.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";

--- a/src/Pages/addUsertask.jsx
+++ b/src/Pages/addUsertask.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from "react-router-dom";
 import axios from "axios";

--- a/src/Pages/addUsertask.jsx
+++ b/src/Pages/addUsertask.jsx
@@ -77,93 +77,103 @@ export default function AddUsertask() {
     return (
         <>
         <InvoiceModal
-          isOpen={showInvoiceModal}
-          onClose={() => { setShowInvoiceModal(false); navigate('/home'); }}
+          open={showInvoiceModal}
+          onClose={() => {
+            setShowInvoiceModal(false);
+            navigate('/home');
+          }}
           invoiceRef={previewRef}
           customerName={User}
           items={invoiceItems}
           remark={Remark}
         />
-        <div className="min-h-screen bg-[#f0f2f5] flex justify-center items-center px-4">
-            <div className="bg-white rounded-2xl shadow-lg w-full max-w-md p-6">
-                <h2 className="text-xl font-semibold mb-4 text-[#075e54]">Add User Task</h2>
-                <form onSubmit={submit} className="space-y-4">
-                    <div>
-                        <label className="block font-medium text-gray-700 mb-1">Select User</label>
-                        <select
-                            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
-                            value={User}
-                            onChange={(e) => setUser(e.target.value)}
-                        >
-                            <option value="">-- Select User --</option>
-                            {userOptions.map((option, index) => (
-                                <option key={index} value={option}>{option}</option>
-                            ))}
-                        </select>
-                    </div>
+        <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+          <div className="bg-white w-full max-w-md rounded-2xl shadow-lg p-6 relative">
+            <button
+              onClick={closeModal}
+              className="absolute right-2 top-2 text-xl text-gray-400 hover:text-green-500"
+              type="button"
+            >
+              ×
+            </button>
+            <h2 className="text-xl font-semibold mb-4 text-center text-[#075e54]">Add User Task</h2>
+            <form onSubmit={submit} className="space-y-4">
+              <div>
+                <label className="block font-medium text-gray-700 mb-1">Select User</label>
+                <select
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                  value={User}
+                  onChange={(e) => setUser(e.target.value)}
+                >
+                  <option value="">-- Select User --</option>
+                  {userOptions.map((option, index) => (
+                    <option key={index} value={option}>{option}</option>
+                  ))}
+                </select>
+              </div>
 
-                    <div>
-                        <label className="block font-medium text-gray-700 mb-1">Task</label>
-                        <input
-                            type="text"
-                            value={Usertask_name}
-                            onChange={(e) => setUsertask_Name(e.target.value)}
-                            placeholder="Enter task"
-                            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
-                            autoFocus
-                        />
-                    </div>
+              <div>
+                <label className="block font-medium text-gray-700 mb-1">Task</label>
+                <input
+                  type="text"
+                  value={Usertask_name}
+                  onChange={(e) => setUsertask_Name(e.target.value)}
+                  placeholder="Enter task"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                  autoFocus
+                />
+              </div>
 
-                    <div className="flex items-center space-x-2">
-                        <input
-                            type="checkbox"
-                            checked={isDeadlineChecked}
-                            onChange={handleDeadlineCheckboxChange}
-                            className="h-4 w-4 text-[#25d366] focus:ring-[#25d366] border-gray-300 rounded"
-                        />
-                        <label className="text-gray-700">Add Deadline</label>
-                    </div>
+              <div className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  checked={isDeadlineChecked}
+                  onChange={handleDeadlineCheckboxChange}
+                  className="h-4 w-4 text-[#25d366] focus:ring-[#25d366] border-gray-300 rounded"
+                />
+                <label className="text-gray-700">Add Deadline</label>
+              </div>
 
-                    {isDeadlineChecked && (
-                        <div>
-                            <label className="block font-medium text-gray-700 mb-1">Deadline</label>
-                            <input
-                                type="date"
-                                value={Deadline}
-                                onChange={(e) => setDeadline(e.target.value)}
-                                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
-                            />
-                        </div>
-                    )}
+              {isDeadlineChecked && (
+                <div>
+                  <label className="block font-medium text-gray-700 mb-1">Deadline</label>
+                  <input
+                    type="date"
+                    value={Deadline}
+                    onChange={(e) => setDeadline(e.target.value)}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                  />
+                </div>
+              )}
 
-                    <div>
-                        <label className="block font-medium text-gray-700 mb-1">Remark</label>
-                        <input
-                            type="text"
-                            value={Remark}
-                            onChange={(e) => setRemark(e.target.value)}
-                            placeholder="Add remark"
-                            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
-                        />
-                    </div>
+              <div>
+                <label className="block font-medium text-gray-700 mb-1">Remark</label>
+                <input
+                  type="text"
+                  value={Remark}
+                  onChange={(e) => setRemark(e.target.value)}
+                  placeholder="Add remark"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#25d366]"
+                />
+              </div>
 
-                    <div className="flex flex-col space-y-2">
-                        <button
-                            type="submit"
-                            className="bg-[#25d366] hover:bg-[#128c7e] text-white font-medium py-2 rounded-lg transition"
-                        >
-                            Submit
-                        </button>
-                        <button
-                            type="button"
-                            className="bg-gray-400 hover:bg-gray-600 text-white font-medium py-2 rounded-lg transition"
-                            onClick={closeModal}
-                        >
-                            Close
-                        </button>
-                    </div>
-                </form>
-            </div>
+              <div className="flex flex-col space-y-2">
+                <button
+                  type="submit"
+                  className="bg-[#25d366] hover:bg-[#128c7e] text-white font-medium py-2 rounded-lg transition"
+                >
+                  Submit
+                </button>
+                <button
+                  type="button"
+                  className="bg-gray-400 hover:bg-gray-600 text-white font-medium py-2 rounded-lg transition"
+                  onClick={closeModal}
+                >
+                  Close
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
         </>
     );

--- a/src/Pages/updateDelivery.jsx
+++ b/src/Pages/updateDelivery.jsx
@@ -1,5 +1,6 @@
+/* eslint-disable react/prop-types */
 // Import statements remain mostly unchanged
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 import Select from "react-select";

--- a/src/Pages/updateDelivery.jsx
+++ b/src/Pages/updateDelivery.jsx
@@ -229,8 +229,8 @@ export default function UpdateDelivery({ onClose, order = {}, mode = "edit" }) {
   return (
     <>
       <ToastContainer />
-      <div className="flex justify-center items-center bg-gray-100 min-h-screen">
-        <div className="bg-white p-6 rounded shadow-md w-full max-w-3xl">
+      <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+        <div className="bg-white p-6 rounded shadow-md w-full max-w-3xl relative">
           <div className="flex justify-between items-center mb-4">
             <h2 className="text-xl font-bold">
               {mode === "edit" ? "Edit Order" : "New Delivery"}


### PR DESCRIPTION
## Summary
- Reworked AddTransaction, AddTransaction1, AddUsertask, AddItem, AddCustomer, OrderUpdate, and UpdateDelivery pages to use the same modal overlay style as AddOrder1
- Updated InvoiceModal usage to `open` prop and added close buttons for consistency
- Simplified AddOrder1's customer modal hook-up after AddCustomer gained its own overlay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 432 problems (419 errors, 13 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a1ff5f4b40832294050b87670e4edb