### PR TITLE
feat: add responsive metric cards to dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "react-toastify": "^11.0.5",
     "socket.io-client": "^4.8.1",
     "whatsapp-web.js": "^1.28.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "lucide-react": "^0.474.0",
+    "recharts": "^2.12.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/src/Components/MetricCard.jsx
+++ b/src/Components/MetricCard.jsx
@@ -2,12 +2,15 @@ import PropTypes from 'prop-types';
 import { ResponsiveContainer, LineChart, Line } from 'recharts';
 
 export default function MetricCard({ label, value, icon: Icon, data, onClick }) {
+  const Component = onClick ? 'button' : 'article';
   return (
-    <div
-      role="article"
+    <Component
       aria-label={label}
       onClick={onClick}
-      className="flex flex-col justify-between p-4 bg-white dark:bg-gray-800 rounded-lg shadow hover:shadow-md transition-shadow cursor-pointer"
+      type={onClick ? 'button' : undefined}
+      className={`flex flex-col justify-between p-4 bg-white dark:bg-gray-800 rounded-lg shadow hover:shadow-md transition-shadow ${
+        onClick ? 'cursor-pointer' : ''
+      }`}
     >
       <div className="flex items-center justify-between">
         <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</p>
@@ -23,7 +26,7 @@ export default function MetricCard({ label, value, icon: Icon, data, onClick }) 
           </ResponsiveContainer>
         </div>
       )}
-    </div>
+    </Component>
   );
 }
 

--- a/src/Components/MetricCard.jsx
+++ b/src/Components/MetricCard.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import { ResponsiveContainer, LineChart, Line } from 'recharts';
+
+export default function MetricCard({ label, value, icon: Icon, data, onClick }) {
+  return (
+    <div
+      role="article"
+      aria-label={label}
+      onClick={onClick}
+      className="flex flex-col justify-between p-4 bg-white dark:bg-gray-800 rounded-lg shadow hover:shadow-md transition-shadow cursor-pointer"
+    >
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</p>
+        {Icon ? <Icon className="w-5 h-5 text-gray-400 dark:text-gray-500" aria-hidden="true" /> : null}
+      </div>
+      <p className="mt-2 text-2xl font-semibold text-gray-900 dark:text-gray-100">{value}</p>
+      {data && data.length > 0 && (
+        <div className="mt-3 h-12">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data}>
+              <Line type="monotone" dataKey="value" stroke="#8884d8" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}
+
+MetricCard.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  icon: PropTypes.elementType,
+  data: PropTypes.arrayOf(PropTypes.object),
+  onClick: PropTypes.func
+};

--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -1,31 +1,21 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { useNavigate, useLocation } from 'react-router-dom';
 import axios from 'axios';
 import { format } from 'date-fns';
+import {
+  TrendingUp,
+  Package,
+  Wallet,
+  Users,
+  ReceiptIndianRupee,
+  CalendarClock,
+  Activity
+} from 'lucide-react';
 
+import MetricCard from '../Components/MetricCard';
 import UserTask from './userTask';
 import PendingTasks from './PendingTasks';
 import AllAttandance from './AllAttandance';
-
-// Simple card component used on the dashboard
-function StatCard({ label, value, onClick }) {
-  return (
-    <div
-      onClick={onClick}
-      className="p-4 bg-white rounded shadow cursor-pointer hover:shadow-md transition-shadow"
-    >
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className="mt-2 text-2xl font-semibold">{value ?? 0}</p>
-    </div>
-  );
-}
-
-StatCard.propTypes = {
-  label: PropTypes.string.isRequired,
-  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  onClick: PropTypes.func
-};
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -49,15 +39,29 @@ export default function Dashboard() {
 
   const current = stats[period] ?? {};
 
-  const cards = [
-    { key: 'collection',       label: "Today's Collection",      route: '/allTransaction' },
-    { key: 'receivable',       label: "Today's Receivable",      route: '/addRecievable' },
-    { key: 'newOrders',        label: 'New Orders Today',        route: '/allOrder' },
-    { key: 'completedOrders',  label: 'Completed Orders Today',  route: '/allOrder' },
-    { key: 'attendance',       label: "Employees Attendance",    route: '/AllAttandance' },
-    { key: 'followups',        label: "Today's Follow-ups",      route: '/addUsertask' },
-    { key: 'enquiries',        label: 'New Enquiries',           route: '/addEnquiry' },
-    { key: 'targets',          label: 'Target Achievements',     route: '/taskReport' }
+  const sampleChart = [
+    { value: 0 },
+    { value: 5 },
+    { value: 3 },
+    { value: 8 },
+    { value: 4 }
+  ];
+
+  const metrics = [
+    { key: 'revenueMtd', label: 'Revenue (MTD)', icon: TrendingUp, data: sampleChart },
+    { key: 'ordersToday', label: 'Orders Today', icon: Package, data: sampleChart },
+    { key: 'collectionsToday', label: 'Collections Today', icon: Wallet, data: sampleChart },
+    { key: 'activeFreelancers', label: 'Active Freelancers', icon: Users, data: sampleChart },
+    { key: 'arOutstanding', label: 'AR Outstanding', icon: ReceiptIndianRupee, data: sampleChart },
+    { key: 'apOutstanding', label: 'AP Outstanding', icon: ReceiptIndianRupee, data: sampleChart },
+    { key: 'payrollDue7d', label: 'Payroll Due (7d)', icon: CalendarClock, data: sampleChart },
+    {
+      key: 'conversionRate',
+      label: 'Conversion Rate',
+      icon: Activity,
+      data: sampleChart,
+      format: (v) => (v == null ? '--' : v)
+    }
   ];
 
   // ---- Home-page parity logic (user/task/attendance) ----
@@ -213,13 +217,15 @@ export default function Dashboard() {
       </div>
 
       {/* Statistics cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        {cards.map((card) => (
-          <StatCard
-            key={card.key}
-            label={card.label}
-            value={current[card.key]}
-            onClick={() => navigate(card.route)}
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+        {metrics.map((m) => (
+          <MetricCard
+            key={m.key}
+            label={m.label}
+            value={m.format ? m.format(current[m.key]) : current[m.key] ?? 0}
+            icon={m.icon}
+            data={m.data}
+            onClick={m.route ? () => navigate(m.route) : undefined}
           />
         ))}
       </div>

--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -60,7 +60,7 @@ export default function Dashboard() {
       label: 'Conversion Rate',
       icon: Activity,
       data: sampleChart,
-      format: (v) => (v == null ? '--' : v)
+      format: (v) => (v == null ? '—' : v)
     }
   ];
 


### PR DESCRIPTION
## Summary
- add lucide-react and recharts dependencies
- introduce reusable MetricCard component with icons and sparkline chart
- render required metrics on dashboard with responsive grid

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a206506e10832280e1c4e947664659