### PR TITLE
Professional dashboard UI refresh

### DIFF
--- a/docs/ui-refresh-notes.md
+++ b/docs/ui-refresh-notes.md
@@ -1,0 +1,3 @@
+# Professional dashboard UI refresh
+
+This branch contains the ChatGPT-generated professional UI refresh for the MIS frontend. The local zip shared in ChatGPT contains the complete updated source files.

--- a/src/components/dashboard/SummaryCard.jsx
+++ b/src/components/dashboard/SummaryCard.jsx
@@ -1,46 +1,94 @@
 import PropTypes from 'prop-types';
 import { alpha } from '@mui/material/styles';
-import { Card, Divider, Stack, Typography } from '@mui/material';
+import { Box, Card, Stack, Typography } from '@mui/material';
 
 const variantStyles = {
-  primary: (theme) => ({ bg: alpha(theme.palette.primary.main, 0.1), color: theme.palette.primary.main }),
-  success: (theme) => ({ bg: alpha(theme.palette.success.main, 0.1), color: theme.palette.success.main }),
-  warning: (theme) => ({ bg: alpha(theme.palette.warning.main, 0.1), color: theme.palette.warning.main }),
-  danger: (theme) => ({ bg: alpha(theme.palette.error.main, 0.1), color: theme.palette.error.main }),
+  primary: (theme) => ({
+    bg: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.14)}, ${alpha(theme.palette.info.main, 0.08)})`,
+    color: theme.palette.primary.main,
+    ring: alpha(theme.palette.primary.main, 0.16),
+  }),
+  success: (theme) => ({
+    bg: `linear-gradient(135deg, ${alpha(theme.palette.success.main, 0.14)}, ${alpha(theme.palette.secondary.main, 0.08)})`,
+    color: theme.palette.success.main,
+    ring: alpha(theme.palette.success.main, 0.16),
+  }),
+  warning: (theme) => ({
+    bg: `linear-gradient(135deg, ${alpha(theme.palette.warning.main, 0.15)}, ${alpha(theme.palette.warning.light, 0.08)})`,
+    color: theme.palette.warning.dark,
+    ring: alpha(theme.palette.warning.main, 0.18),
+  }),
+  danger: (theme) => ({
+    bg: `linear-gradient(135deg, ${alpha(theme.palette.error.main, 0.14)}, ${alpha(theme.palette.error.light, 0.08)})`,
+    color: theme.palette.error.main,
+    ring: alpha(theme.palette.error.main, 0.16),
+  }),
 };
 
-export default function SummaryCard({ title, value, icon: Icon, variant = 'primary', trend }) {
+export default function SummaryCard({ title, value, icon: Icon, variant = 'primary', trend, sx }) {
   return (
-    <Card elevation={0} sx={{ p: 1.25, height: '100%' }}>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1.25}>
-        <Stack spacing={0.4}>
-          <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+    <Card
+      elevation={0}
+      sx={(theme) => {
+        const v = (variantStyles[variant] || variantStyles.primary)(theme);
+        return {
+          p: { xs: 1.05, md: 1.2 },
+          height: '100%',
+          position: 'relative',
+          overflow: 'hidden',
+          background: v.bg,
+          borderColor: v.ring,
+          transition: 'transform .16s ease, box-shadow .16s ease, border-color .16s ease',
+          '&:hover': {
+            transform: 'translateY(-2px)',
+            boxShadow: '0 18px 36px rgba(15,23,42,0.10)',
+            borderColor: v.color,
+          },
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            inset: 'auto -34px -42px auto',
+            width: 105,
+            height: 105,
+            borderRadius: '50%',
+            background: alpha(v.color, 0.08),
+          },
+          ...sx,
+        };
+      }}
+    >
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1.1} sx={{ position: 'relative', zIndex: 1 }}>
+        <Stack spacing={0.45} minWidth={0}>
+          <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.55, fontWeight: 850 }} noWrap>
             {title}
           </Typography>
-          <Typography variant="h4" sx={{ lineHeight: 1.1 }}>
+          <Typography variant="h4" sx={{ lineHeight: 1, color: 'text.primary' }} noWrap>
             {value}
           </Typography>
+          {trend ? <Typography variant="caption" color="text.secondary" noWrap>{trend}</Typography> : null}
         </Stack>
         {Icon ? (
-          <Stack
-            alignItems="center"
-            justifyContent="center"
+          <Box
             sx={(theme) => {
-              const v = variantStyles[variant] || variantStyles.primary;
-              const { bg, color } = v(theme);
-              return { bgcolor: bg, color, width: 36, height: 36, borderRadius: 1.5 };
+              const v = (variantStyles[variant] || variantStyles.primary)(theme);
+              return {
+                display: 'grid',
+                placeItems: 'center',
+                bgcolor: alpha('#ffffff', 0.9),
+                color: v.color,
+                width: 38,
+                height: 38,
+                borderRadius: 2,
+                border: `1px solid ${alpha(v.color, 0.14)}`,
+                boxShadow: `0 10px 20px ${alpha(v.color, 0.10)}`,
+                flexShrink: 0,
+              };
             }}
           >
-            <Icon sx={{ fontSize: 20 }} />
-          </Stack>
+            <Icon sx={{ fontSize: 21 }} />
+          </Box>
         ) : null}
       </Stack>
-      {trend ? (
-        <>
-          <Divider sx={{ my: 0.8 }} />
-          <Typography variant="caption" color="text.secondary">{trend}</Typography>
-        </>
-      ) : null}
     </Card>
   );
 }
@@ -51,4 +99,5 @@ SummaryCard.propTypes = {
   icon: PropTypes.elementType,
   variant: PropTypes.oneOf(['primary', 'success', 'warning', 'danger']),
   trend: PropTypes.string,
+  sx: PropTypes.object,
 };

--- a/src/index.css
+++ b/src/index.css
@@ -3,20 +3,25 @@
 @tailwind utilities;
 
 :root {
-  --crm-primary: #38bdf8;
-  --crm-primary-dark: #0f172a;
-  --crm-accent: #0284c7;
-  --crm-bg: #eef6fb;
+  --crm-primary: #2563eb;
+  --crm-primary-dark: #1e3a8a;
+  --crm-secondary: #0f766e;
+  --crm-accent: #14b8a6;
+  --crm-bg: #eef3f8;
+  --crm-bg-soft: #f8fafc;
   --crm-surface: #ffffff;
-  --crm-border: #d7e6ef;
+  --crm-surface-soft: #f8fafc;
+  --crm-border: #dbe5ef;
   --crm-text: #0f172a;
-  --crm-muted: #475569;
+  --crm-muted: #64748b;
+  --crm-sidebar: #0b1220;
+  --crm-sidebar-2: #10243f;
   --wa-bg: #efeae2;
   --wa-panel: #ffffff;
   --wa-header: #f0f2f5;
   --wa-green: #25d366;
   --wa-green-dark: #128c7e;
-  font-family: Inter, Roboto, 'Segoe UI', Arial, sans-serif;
+  font-family: Inter, 'Segoe UI', Roboto, Arial, sans-serif;
 }
 
 * {
@@ -30,13 +35,22 @@ body,
   margin: 0;
   width: 100%;
   height: 100%;
-  background-color: var(--crm-bg);
+  background: var(--crm-bg);
   color: var(--crm-text);
 }
 
 body {
   overflow-x: hidden;
   overflow-y: auto;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: geometricPrecision;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
 }
 
 a {
@@ -44,24 +58,46 @@ a {
   text-decoration: none;
 }
 
+img,
+svg,
+video,
+canvas {
+  max-width: 100%;
+}
+
+.MuiContainer-root {
+  max-width: none !important;
+}
+
 .form-control,
 input.form-control,
 select.form-control,
-textarea.form-control {
+textarea.form-control,
+.form-select {
   width: 100%;
-  min-height: 36px;
+  min-height: 38px;
   border: 1px solid var(--crm-border);
-  border-radius: 10px !important;
-  padding: 6px 10px;
+  border-radius: 12px !important;
+  padding: 7px 11px;
   font-size: 13px;
   color: var(--crm-text);
   background: rgba(255, 255, 255, 0.96);
+  transition: border-color .16s ease, box-shadow .16s ease, background-color .16s ease;
 }
 
-.form-control:focus {
+.form-control:focus,
+.form-select:focus {
   outline: none;
-  border-color: #38bdf8;
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.15);
+  border-color: var(--crm-primary);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+  background-color: #fff;
+}
+
+.btn,
+button.btn {
+  border-radius: 12px;
+  font-weight: 800;
+  min-height: 36px;
 }
 
 .table,
@@ -69,52 +105,64 @@ table.table,
 .table-bordered,
 .table-striped {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   background: var(--crm-surface);
   border: 1px solid var(--crm-border);
-  border-radius: 12px;
+  border-radius: 16px;
   overflow: hidden;
   font-size: 12.5px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
 }
 
 .table th,
 .table td,
 table th,
 table td {
-  border: 1px solid #e8eff5;
-  padding: 7px 9px;
+  border-bottom: 1px solid #e8eff5;
+  padding: 8px 10px;
   vertical-align: middle;
 }
 
 .table th,
 table th {
-  background: #f4f9fc;
+  background: #f8fafc;
   color: var(--crm-muted);
-  font-weight: 700;
+  font-weight: 850;
   white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.table tbody tr:hover,
+table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.035);
 }
 
 .card,
 .modal-content {
-  background: var(--crm-surface);
+  background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(248,250,252,0.94));
   border: 1px solid var(--crm-border);
-  border-radius: 14px;
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.07);
 }
 
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.5);
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 16px;
+  z-index: 1300;
 }
 
 .modal-content {
-  padding: 14px;
-  width: min(96vw, 620px);
+  padding: 16px;
+  width: min(96vw, 680px);
 }
 
 .text-ellipsis {
@@ -123,22 +171,61 @@ table th {
   text-overflow: ellipsis;
 }
 
-.overflow-safe {
+.overflow-safe,
+.table-responsive {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.page-shell {
+  width: 100%;
+}
+
+.dashboard-glass {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(219, 229, 239, 0.9);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(14px);
 }
 
 .whatsapp-wallpaper {
   background-color: var(--wa-bg);
   background-image:
-    radial-gradient(rgba(17, 27, 33, 0.04) 1px, transparent 1px),
+    radial-gradient(rgba(17, 27, 33, 0.045) 1px, transparent 1px),
     radial-gradient(rgba(17, 27, 33, 0.03) 1px, transparent 1px);
   background-size: 22px 22px, 34px 34px;
   background-position: 0 0, 11px 11px;
 }
 
+@media (max-width: 768px) {
+  .table,
+  table.table,
+  .table-bordered,
+  .table-striped {
+    font-size: 11.8px;
+    border-radius: 14px;
+  }
+
+  .table th,
+  .table td,
+  table th,
+  table td {
+    padding: 7px 8px;
+  }
+
+  .card,
+  .modal-content {
+    border-radius: 16px;
+  }
+}
+
 @media print {
   .no-print,
-  .btn {
+  .btn,
+  .MuiFab-root,
+  .MuiBottomNavigation-root,
+  .MuiDrawer-root,
+  .MuiAppBar-root {
     display: none !important;
   }
 
@@ -148,5 +235,6 @@ table th {
 
   body {
     margin: 1cm;
+    background: #fff;
   }
 }


### PR DESCRIPTION
This PR starts the professional MIS frontend UI refresh.

Committed in GitHub branch:
- Global CSS refresh for professional dashboard look
- Dashboard summary card redesign
- UI refresh notes

Also prepared complete updated frontend zip in ChatGPT with additional local updates for theme, layout, navbar, sidebar, shared UI shell, form shell, report shell, and dashboard hero section. I could not safely push every large edited file through the connector because one large source-file update was blocked by safety checks, and local npm install/build could not complete in the session due timeout.

Recommended next step: download the zip from ChatGPT, replace the frontend folder locally, run npm install and npm run build, then push/merge after visual review.